### PR TITLE
Exposing PulseStorage Contents

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,0 +1,8 @@
+## pending/current ##
+
+- Serialization / Storage:
+
+    - Added functionality to easily access available content/identifiers in `PulseStorage` and `StorageBackend`.
+    - DEPRECATED `list_contents()`` of `StorageBackend` (use `contents property` instead).
+
+## 0.1.2 ##

--- a/qupulse/serialization.py
+++ b/qupulse/serialization.py
@@ -902,15 +902,15 @@ class PulseStorage(MutableMapping[str, Serializable]):
         except KeyError:
             pass
 
-    def __len__(self) -> None:
-        raise NotImplementedError("len(PulseStorage) has currently no meaningful semantics and is not implemented."
-                                  " If you require this feature, please create a feature request at \n"
-                                  "https://github.com/qutech/qupulse/issues/new")
+    @property
+    def contents(self) -> Iterable[str]:
+        return self._storage_backend.list_contents()
 
-    def __iter__(self) -> None:
-        raise NotImplementedError("iter(PulseStorage) has currently no meaningful semantics and is not implemented."
-                                  " If you require this feature, please create a feature request at \n"
-                                  "https://github.com/qutech/qupulse/issues/new")
+    def __len__(self) -> int:
+        return len(self._storage_backend)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._storage_backend)
 
     def overwrite(self, identifier: str, serializable: Serializable) -> None:
         """Explicitly overwrites a pulse.

--- a/tests/serialization_dummies.py
+++ b/tests/serialization_dummies.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Any, Callable, Set
+from typing import Union, Dict, Any, Callable, Iterator
 
 from qupulse.serialization import Serializer, Serializable, StorageBackend
 
@@ -30,8 +30,8 @@ class DummyStorageBackend(StorageBackend):
     def delete(self, identifier: str) -> None:
         del self.stored_items[identifier]
 
-    def list_contents(self) -> Set[str]:
-        return set(self.stored_items.keys())
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.stored_items)
 
 
 class DummySerializer(Serializer):

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -8,8 +8,8 @@ import json
 from unittest import mock
 from abc import ABCMeta, abstractmethod
 
-from tempfile import TemporaryDirectory, TemporaryFile
-from typing import Optional, Any, Dict, Tuple, Iterable
+from tempfile import TemporaryDirectory, NamedTemporaryFile, TemporaryFile
+from typing import Optional, Any, Tuple
 
 from qupulse.serialization import FilesystemBackend, CachingBackend, Serializable, JSONSerializableEncoder,\
     ZipFileBackend, AnonymousSerializable, DictBackend, PulseStorage, JSONSerializableDecoder, Serializer,\
@@ -442,7 +442,7 @@ class ZipFileBackendTests(unittest.TestCase):
             ZipFileBackend(invalid_path)
 
     def test_init_file_exists_not_zip(self):
-        with TemporaryFile() as tmp_file:
+        with NamedTemporaryFile() as tmp_file:
             with self.assertRaises(FileExistsError):
                 ZipFileBackend(tmp_file.name)
 

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -960,15 +960,28 @@ class PulseStorageTests(unittest.TestCase):
         self.assertEqual({}, backend.stored_items)
         self.assertEqual(pulse_storage.temporary_storage, {})
 
+    @mock.patch.multiple(StorageBackend, __abstractmethods__=set())
     def test_len(self) -> None:
-        pulse_storage = PulseStorage(DummyStorageBackend())
-        with self.assertRaisesRegex(NotImplementedError, "request"):
-            len(pulse_storage)
+        with mock.patch.object(StorageBackend, '__len__', return_value=5) as len_mock:
+            pulse_storage = PulseStorage(StorageBackend())
+            self.assertEqual(5, len(pulse_storage))
+            self.assertEqual(1, len_mock.call_count)
 
+    @mock.patch.multiple(StorageBackend, __abstractmethods__=set())
     def test_iter(self) -> None:
-        pulse_storage = PulseStorage(DummyStorageBackend())
-        with self.assertRaisesRegex(NotImplementedError, "request"):
-            iter(pulse_storage)
+        data = ['hugo', 'ilse', 'foo.bar']
+        with mock.patch.object(StorageBackend, '__iter__', return_value=iter(data)) as iter_mock:
+            pulse_storage = PulseStorage(StorageBackend())
+            self.assertEqual(set(data), set(iter(pulse_storage)))
+            self.assertEqual(1, iter_mock.call_count)
+
+    @mock.patch.multiple(StorageBackend, __abstractmethods__=set())
+    def test_contents(self) -> None:
+        data = ['hugo', 'ilse', 'foo.bar']
+        with mock.patch.object(StorageBackend, 'list_contents', return_value=data) as lc_mock:
+            pulse_storage = PulseStorage(StorageBackend())
+            self.assertEqual(set(data), set(iter(pulse_storage)))
+            self.assertEqual(1, lc_mock.call_count)
 
     def test_deserialize_storage_is_default_registry(self) -> None:
         backend = DummyStorageBackend()


### PR DESCRIPTION
Implements and closes #350 .
In addition to adding `__iter__`, `__len__` and property contents to `PulseStorage`, I also implemented them for `StorageBackend` and derived classes (so `PulseStorage` can really just forward calls). Deprecated method `StorageBackend.list_contents` in favor of property `StorageBackend.contents`.