### PR TITLE
Fix/expression scalar hash

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,8 @@
 ## pending/current ##
 
+- Expressions:
+    - Make ExpressionScalar hashable
+
 ## 0.2 ##
 
 - General:

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -268,6 +268,9 @@ class ExpressionScalar(Expression):
         """Enable comparisons with Numbers"""
         return self._sympified_expression == self._sympify(other)
 
+    def __hash__(self) -> int:
+        return hash(self._sympified_expression)
+
     def __add__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
         return self.make(self._sympified_expression.__add__(self._sympify(other)))
 

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -235,6 +235,11 @@ class ExpressionScalarTests(unittest.TestCase):
         s = 'a    *    b'
         self.assertEqual(ExpressionScalar(s).original_expression, s)
 
+    def test_hash(self):
+        expected = {ExpressionScalar(2), ExpressionScalar('a')}
+        sequence = [ExpressionScalar(2), ExpressionScalar('a'), ExpressionScalar(2), ExpressionScalar('a')]
+        self.assertEqual(expected, set(sequence))
+
     def test_undefined_comparison(self):
         valued = ExpressionScalar(2)
         unknown = ExpressionScalar('a')


### PR DESCRIPTION
This bug made FunctionPulseTemplate unusable as it could not be hashed.