### PR TITLE
Added time_slice keyword argument to plot() and render() functions.

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -7,6 +7,8 @@
     - `AtomicMultichannelPulseTemplate`:
         - Add duration keyword argument & example (see MultiChannelTemplates notebook)
         - Make duration equality check approximate (numeric tolerance)
+    - Plotting:
+        - Add `time_slice` keyword argument to render() and plot()
 
 - Expressions:
     - Make ExpressionScalar hashable

--- a/qupulse/pulses/plotting.py
+++ b/qupulse/pulses/plotting.py
@@ -108,8 +108,10 @@ def iter_instruction_block(instruction_block: AbstractInstructionBlock,
 
 def render(program: Union[AbstractInstructionBlock, Loop],
            sample_rate: Real=10.0,
-           render_measurements=False) -> Union[Tuple[np.ndarray, Dict[ChannelID, np.ndarray]],
-                                               Tuple[np.ndarray, Dict[ChannelID, np.ndarray], List[MeasurementWindow]]]:
+           render_measurements: bool=False,
+           time_slice: Tuple[Real, Real]=None) -> Union[Tuple[np.ndarray, Dict[ChannelID, np.ndarray]],
+                                                        Tuple[np.ndarray, Dict[ChannelID, np.ndarray],
+                                                              List[MeasurementWindow]]]:
     """'Renders' a pulse program.
 
         Samples all contained waveforms into an array according to the control flow of the program.
@@ -118,7 +120,8 @@ def render(program: Union[AbstractInstructionBlock, Loop],
             program: The pulse (sub)program to render. Can be represented either by a Loop object or the more
                 old-fashioned InstructionBlock.
             sample_rate: The sample rate in GHz.
-            render_measurements: If True, the third return value is a list of measurement windows
+            render_measurements: If True, the third return value is a list of measurement windows.
+            time_slice: The time slice to be plotted. If None, the entire pulse will be shown.
 
         Returns:
             A tuple (times, values, measurements). times is a numpy.ndarray of dimensions sample_count where
@@ -129,9 +132,13 @@ def render(program: Union[AbstractInstructionBlock, Loop],
         """
 
     if isinstance(program, AbstractInstructionBlock):
+        warnings.warn("InstructionBlock API is deprecated", DeprecationWarning)
+        if time_slice is not None:
+            raise ValueError("Keyword argument time_slice is not supported when rendering instruction blocks")
         return _render_instruction_block(program, sample_rate=sample_rate, render_measurements=render_measurements)
     elif isinstance(program, Loop):
-        return _render_loop(program, sample_rate=sample_rate, render_measurements=render_measurements)
+        return _render_loop(program, sample_rate=sample_rate,
+                            render_measurements=render_measurements, time_slice=time_slice)
 
 
 def _render_instruction_block(sequence: AbstractInstructionBlock,
@@ -173,15 +180,21 @@ def _render_instruction_block(sequence: AbstractInstructionBlock,
 
 def _render_loop(loop: Loop,
                  sample_rate: Real,
-                 render_measurements: bool) -> Union[Tuple[np.ndarray, Dict[ChannelID, np.ndarray]],
-                                                     Tuple[np.ndarray, Dict[ChannelID, np.ndarray],
-                                                           List[MeasurementWindow]]]:
+                 render_measurements: bool,
+                 time_slice: Tuple[Real, Real] = None) -> Union[Tuple[np.ndarray, Dict[ChannelID, np.ndarray]],
+                                                                Tuple[np.ndarray, Dict[ChannelID, np.ndarray],
+                                                                List[MeasurementWindow]]]:
     """The specific implementation of render for Loop arguments."""
     waveform = to_waveform(loop)
     channels = waveform.defined_channels
 
-    sample_count = waveform.duration * sample_rate + 1
-    times = np.linspace(0., float(waveform.duration), num=int(sample_count), dtype=float)
+    if time_slice is None:
+        time_slice = (0, waveform.duration)
+    elif time_slice[1] < time_slice[0] or time_slice[0] < 0 or time_slice[1] < 0:
+        raise ValueError("time_slice is not valid.")
+
+    sample_count = (time_slice[1] - time_slice[0]) * sample_rate + 1
+    times = np.linspace(float(time_slice[0]), float(time_slice[1]), num=int(sample_count), dtype=float)
     times[-1] = np.nextafter(times[-1], times[-2])
 
     voltages = {}
@@ -193,7 +206,9 @@ def _render_loop(loop: Loop,
         measurement_dict = loop.get_measurement_windows()
         measurement_list = []
         for name, (begins, lengths) in measurement_dict.items():
-            measurement_list.extend(zip(itertools.repeat(name), begins, lengths))
+            measurement_list.extend(m
+                                    for m in zip(itertools.repeat(name), begins, lengths)
+                                    if m[1]+m[2] > time_slice[0] and m[1] < time_slice[1])
         measurements = sorted(measurement_list, key=operator.itemgetter(1))
     else:
         measurements = []
@@ -210,6 +225,7 @@ def plot(pulse: PulseTemplate,
          plot_measurements: Optional[Set[str]]=None,
          stepped: bool=True,
          maximum_points: int=10**6,
+         time_slice: Tuple[Real, Real]=None,
          **kwargs) -> Any:  # pragma: no cover
     """Plots a pulse using matplotlib.
 
@@ -229,6 +245,7 @@ def plot(pulse: PulseTemplate,
         stepped: If true pyplot.step is used for plotting
         plot_measurements: If specified measurements in this set will be plotted. If omitted no measurements will be.
         maximum_points: If the sampled waveform is bigger, it is not plotted
+        time_slice: The time slice to be plotted. If None, the entire pulse will be shown.
         kwargs: Forwarded to pyplot. Overwrites other settings.
     Returns:
         matplotlib.pyplot.Figure instance in which the pulse is rendered
@@ -249,7 +266,10 @@ def plot(pulse: PulseTemplate,
                                    measurement_mapping={w: w for w in pulse.measurement_names})
 
     if program is not None:
-        times, voltages, measurements = render(program, sample_rate, render_measurements=plot_measurements)
+        times, voltages, measurements = render(program,
+                                               sample_rate,
+                                               render_measurements=plot_measurements,
+                                               time_slice=time_slice)
     else:
         times, voltages, measurements = np.array([]), dict(), []
 
@@ -263,6 +283,9 @@ def plot(pulse: PulseTemplate,
         return None
     else:
         duration = times[-1]
+
+    if time_slice is None:
+        time_slice = (0, duration)
 
     legend_handles = []
     if axes is None:
@@ -303,7 +326,7 @@ def plot(pulse: PulseTemplate,
     min_voltage = min((min(channel, default=0) for channel in voltages.values()), default=0)
 
     # add some margins in the presentation
-    axes.set_xlim(-0.5, duration + 0.5)
+    axes.set_xlim(-0.5+time_slice[0], time_slice[1] + 0.5)
     axes.set_ylim(min_voltage - 0.1*(max_voltage-min_voltage), max_voltage + 0.1*(max_voltage-min_voltage))
     axes.set_xlabel('Time (ns)')
     axes.set_ylabel('Voltage (a.u.)')

--- a/tests/pulses/plotting_tests.py
+++ b/tests/pulses/plotting_tests.py
@@ -1,12 +1,12 @@
 import unittest
 import numpy
 
-from qupulse.pulses.plotting import PlottingNotPossibleException, render, iter_waveforms, iter_instruction_block,plot, _render_instruction_block
+from qupulse.pulses.plotting import PlottingNotPossibleException, render, iter_waveforms, iter_instruction_block, plot
 from qupulse._program.instructions import InstructionBlock
 from qupulse.pulses.table_pulse_template import TablePulseTemplate
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate
 from qupulse.pulses.sequencing import Sequencer
-from qupulse._program._loop import Loop, MultiChannelProgram
+from qupulse._program._loop import MultiChannelProgram, Loop
 
 from tests.pulses.sequencing_dummies import DummyWaveform, DummyInstruction, DummyPulseTemplate
 
@@ -25,7 +25,7 @@ class PlotterTests(unittest.TestCase):
         self.assertEqual(channel_data, dict())
         numpy.testing.assert_equal(time, numpy.empty(0))
 
-    def test_iter_waveforms(self):
+    def test_iter_waveforms(self) -> None:
         wf1 = DummyWaveform(duration=7)
         wf2 = DummyWaveform(duration=5)
         wf3 = DummyWaveform(duration=3)
@@ -43,7 +43,7 @@ class PlotterTests(unittest.TestCase):
         for idx, (expected, received) in enumerate(zip([wf1, wf2, wf1, wf2, wf1, wf3], iter_waveforms(main_block))):
             self.assertIs(expected, received, msg="Waveform {} is wrong".format(idx))
 
-    def test_iter_waveform_exceptions(self):
+    def test_iter_waveform_exceptions(self) -> None:
         wf1 = DummyWaveform(duration=7)
         wf2 = DummyWaveform(duration=5)
         wf3 = DummyWaveform(duration=3)
@@ -72,7 +72,7 @@ class PlotterTests(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(iter_waveforms(main_block))
 
-    def test_iter_instruction_block(self):
+    def test_iter_instruction_block(self) -> None:
         wf1 = DummyWaveform(duration=7)
         wf2 = DummyWaveform(duration=5)
         wf3 = DummyWaveform(duration=3)
@@ -94,7 +94,7 @@ class PlotterTests(unittest.TestCase):
         self.assertEqual([('m', 8, 2), ('m', 20, 2)], measurements)
         self.assertEqual(total_time, 34)
 
-    def test_iter_instruction_block_exceptions(self):
+    def test_iter_instruction_block_exceptions(self) -> None:
         wf1 = DummyWaveform(duration=7)
         wf2 = DummyWaveform(duration=5)
         wf3 = DummyWaveform(duration=3)
@@ -127,55 +127,68 @@ class PlotterTests(unittest.TestCase):
             iter_instruction_block(main_block, False)
 
     def test_render(self) -> None:
-        wf1 = DummyWaveform(duration=19)
-        wf2 = DummyWaveform(duration=21)
+        with self.assertWarnsRegex(DeprecationWarning, ".*InstructionBlock.*"):
+            wf1 = DummyWaveform(duration=19)
+            wf2 = DummyWaveform(duration=21)
 
-        block = InstructionBlock()
-        block.add_instruction_exec(wf1)
-        block.add_instruction_meas([('asd', 0, 1)])
-        block.add_instruction_exec(wf2)
+            block = InstructionBlock()
+            block.add_instruction_exec(wf1)
+            block.add_instruction_meas([('asd', 0, 1)])
+            block.add_instruction_exec(wf2)
 
-        wf1_expected = ('A', [0, 2, 4, 6, 8, 10, 12, 14, 16, 18])
-        wf2_expected = ('A', [x-19 for x in [20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40]])
-        wf1_output_array_len_expected = len(wf1_expected[1])
-        wf2_output_array_len_expected = len(wf2_expected[1])
+            wf1_expected = ('A', [0, 2, 4, 6, 8, 10, 12, 14, 16, 18])
+            wf2_expected = ('A', [x-19 for x in [20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40]])
+            wf1_output_array_len_expected = len(wf1_expected[1])
+            wf2_output_array_len_expected = len(wf2_expected[1])
 
-        wf1.sample_output = numpy.linspace(start=4, stop=5, num=len(wf1_expected[1]))
-        wf2.sample_output = numpy.linspace(6, 7, num=len(wf2_expected[1]))
+            wf1.sample_output = numpy.linspace(start=4, stop=5, num=len(wf1_expected[1]))
+            wf2.sample_output = numpy.linspace(6, 7, num=len(wf2_expected[1]))
 
-        expected_times = numpy.arange(start=0, stop=42, step=2)
-        expected_result = numpy.concatenate((wf1.sample_output, wf2.sample_output))
+            expected_times = numpy.arange(start=0, stop=42, step=2)
+            expected_result = numpy.concatenate((wf1.sample_output, wf2.sample_output))
 
-        times, voltages, _ = render(block, sample_rate=0.5)
+            times, voltages, _ = render(block, sample_rate=0.5)
 
-        self.assertEqual(len(wf1.sample_calls), 1)
-        self.assertEqual(len(wf2.sample_calls), 1)
+            self.assertEqual(len(wf1.sample_calls), 1)
+            self.assertEqual(len(wf2.sample_calls), 1)
 
-        self.assertEqual(wf1_expected[0], wf1.sample_calls[0][0])
-        self.assertEqual(wf2_expected[0], wf2.sample_calls[0][0])
+            self.assertEqual(wf1_expected[0], wf1.sample_calls[0][0])
+            self.assertEqual(wf2_expected[0], wf2.sample_calls[0][0])
 
-        numpy.testing.assert_almost_equal(wf1_expected[1], wf1.sample_calls[0][1])
-        numpy.testing.assert_almost_equal(wf2_expected[1], wf2.sample_calls[0][1])
+            numpy.testing.assert_almost_equal(wf1_expected[1], wf1.sample_calls[0][1])
+            numpy.testing.assert_almost_equal(wf2_expected[1], wf2.sample_calls[0][1])
 
-        self.assertEqual(wf1_output_array_len_expected, len(wf1.sample_calls[0][2]))
-        self.assertEqual(wf2_output_array_len_expected, len(wf2.sample_calls[0][2]))
+            self.assertEqual(wf1_output_array_len_expected, len(wf1.sample_calls[0][2]))
+            self.assertEqual(wf2_output_array_len_expected, len(wf2.sample_calls[0][2]))
 
-        self.assertEqual(voltages.keys(), dict(A=0).keys())
+            self.assertEqual(voltages.keys(), dict(A=0).keys())
 
-        numpy.testing.assert_almost_equal(expected_times, times)
-        numpy.testing.assert_almost_equal(expected_result, voltages['A'])
-        self.assertEqual(expected_result.shape, voltages['A'].shape)
+            numpy.testing.assert_almost_equal(expected_times, times)
+            numpy.testing.assert_almost_equal(expected_result, voltages['A'])
+            self.assertEqual(expected_result.shape, voltages['A'].shape)
 
-        times, voltages, measurements = render(block, sample_rate=0.5, render_measurements=True)
-        self.assertEqual(voltages.keys(), dict(A=0).keys())
+            times, voltages, measurements = render(block, sample_rate=0.5, render_measurements=True)
+            self.assertEqual(voltages.keys(), dict(A=0).keys())
 
-        numpy.testing.assert_almost_equal(expected_times, times)
-        numpy.testing.assert_almost_equal(expected_result, voltages['A'])
-        self.assertEqual(expected_result.shape, voltages['A'].shape)
+            numpy.testing.assert_almost_equal(expected_times, times)
+            numpy.testing.assert_almost_equal(expected_result, voltages['A'])
+            self.assertEqual(expected_result.shape, voltages['A'].shape)
 
-        self.assertEqual(measurements, [('asd', 19, 1)])
+            self.assertEqual(measurements, [('asd', 19, 1)])
 
-    def test_render_loop_compare(self):
+    def test_render_block_time_slice(self) -> None:
+        with self.assertWarnsRegex(DeprecationWarning, ".*InstructionBlock.*"):
+            with self.assertRaises(ValueError):
+                wf1 = DummyWaveform(duration=19)
+                wf2 = DummyWaveform(duration=21)
+
+                block = InstructionBlock()
+                block.add_instruction_exec(wf1)
+                block.add_instruction_exec(wf2)
+
+                times, voltages, _ = render(block, sample_rate=0.5, time_slice=(1, 16))
+
+    def test_render_loop_compare(self) -> None:
         wf1 = DummyWaveform(duration=19)
         wf2 = DummyWaveform(duration=21)
 
@@ -199,7 +212,31 @@ class PlotterTests(unittest.TestCase):
         numpy.testing.assert_equal(block_voltages, loop_voltages)
         self.assertEqual(block_measurements, loop_measurements)
 
-    def test_render_warning(self):
+    def test_render_loop_sliced(self) -> None:
+        wf = DummyWaveform(duration=19)
+
+        full_times = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+        wf.sample_output = numpy.linspace(start=4, stop=5, num=len(full_times))[3:7]
+
+        full_measurements = [('foo', 1, 3), ('bar', 5, 2), ('foo', 7, 3), ('bar', 11, 2), ('foo', 15, 3)]
+        loop = Loop(waveform=wf, measurements=full_measurements)
+
+        expected_times = full_times[3:7]
+        expected_measurements = full_measurements[1:4]
+
+        times, voltages, measurements = render(loop, sample_rate=0.5, render_measurements=True, time_slice=(6, 12))
+
+        numpy.testing.assert_almost_equal(expected_times, times)
+        numpy.testing.assert_almost_equal(wf.sample_output, voltages['A'])
+        self.assertEqual(expected_measurements, measurements)
+
+    def test_render_loop_invalid_slice(self) -> None:
+        with self.assertRaises(ValueError):
+            render(Loop(waveform=DummyWaveform()), time_slice=(5, 1))
+            render(Loop(waveform=DummyWaveform()), time_slice=(-1, 4))
+            render(Loop(waveform=DummyWaveform()), time_slice=(-7, -3))
+
+    def test_render_warning(self) -> None:
         wf1 = DummyWaveform(duration=19)
         wf2 = DummyWaveform(duration=21)
 


### PR DESCRIPTION
time_slice is a tuple of start and end time specifying the interval that should be plotted.
Closes #187 ; wait for feedback from requester before merging.

Internally, the entire pulse template will still be transformed into a program (that includes parts outside the time_slice interval) but only the time_slice interval of the resulting waveform will be sampled.

This was the easiest way to do it, everything else would have required some deeper changes to plotting/program creation.