### PR TITLE
Travis Reconfiguration to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,28 +11,21 @@ env:
 sudo: false
 
 #these directories are persistent
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $HOME/.cache/miniconda3_pkgs
-    - $HOME/Downloads
+cache: pip
+
+# install dependencies for gmpy2
+addons:
+  apt:
+    update: true
+    packages:
+      - libgmp-dev
+      - libmpfr-dev
+      - libmpc-dev
 
 # Setup anaconda
 before_install:
-# install miniconda with symlink of pkg dir to cache
-  - chmod +x ./install_miniconda3.sh
-  - ./install_miniconda3.sh
-#
-  - export PATH=$HOME/miniconda3/bin:$PATH
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip
-  - conda install -q -n test-environment gmpy2
-  - source activate test-environment
   - pip install coverage coveralls
 install:
-  - pip install -r requirements.txt
   - pip install .$INSTALL_EXTRAS
 script:
   - "coverage run --source=qupulse --rcfile=coverage.ini setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
 language: python
 python:
-  - "3.5"
-  - "3.6"
+  - 3.5
+  - 3.6
 env:
   - INSTALL_EXTRAS=[VISA,plotting]
   - INSTALL_EXTRAS=[VISA,plotting,Faster-fractions]
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: INSTALL_EXTRAS=[VISA,plotting]
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: INSTALL_EXTRAS=[VISA,plotting,Faster-fractions]
 
 #use container based infrastructure
 sudo: false

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,8 @@
 
 - General:
     - Introduce qupulse.utils.isclose (an alias for math.isclose if available)
+    - Dropped support for Python 3.4 in setup.py due to incompatible syntax in qupulse.
+    - Official support for Python 3.7 has begun.
 
 - Pulse Templates:
     - `AtomicMultichannelPulseTemplate`:

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,10 @@ def extract_version(version_file):
     raise RuntimeError("Unable to find version string.")
 
 
-if sys.version_info < (3, 4):
-    sys.stderr.write('ERROR: You need Python 3.4 or later '
+if sys.version_info < (3, 5):
+    sys.stderr.write('ERROR: You need Python 3.5 or later '
                      'to install the qupulse package.\n')
     exit(1)
-
-if sys.version_info < (3, 5):
-    requires_typing = ['typing==3.5.0']
-else:
-    requires_typing = []
 
 packages = [package for package in find_packages()
             if package.startswith('qupulse')] + ['qctoolkit']
@@ -40,8 +35,8 @@ setup(name='qupulse',
       author='Quantum Technology Group and Chair of Software Engineering, RWTH Aachen University',
       package_dir={'qupulse': 'qupulse', 'qctoolkit': 'qctoolkit'},
       packages=packages,
-      python_requires='>=3.4',
-      install_requires=['sympy>=1.1.1', 'numpy', 'cached_property'] + requires_typing,
+      python_requires='>=3.5',
+      install_requires=['sympy>=1.1.1', 'numpy', 'cached_property'],
       extras_require={
           'plotting': ['matplotlib'],
           'VISA': ['pyvisa'],

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import contextlib
 import math
+import sys
 
 from typing import Union
 
@@ -238,24 +239,17 @@ class GetFreeSymbolsTests(TestCase):
         self.assertEqual({'a', 'b', 'i', 'j'}, set(get_variables(expr)))
 
 
-class EvaluationTests(TestCase):
-    def evaluate(self, expression: Union[sympy.Expr, np.ndarray], parameters):
-        if isinstance(expression, np.ndarray):
-            variables = set.union(*map(set, map(get_variables, expression.flat)))
-        else:
-            variables = get_variables(expression)
-        return evaluate_lambdified(expression, variables=list(variables), parameters=parameters, lambdified=None)[0]
+class EvaluationTestsBase:
 
     def test_eval_simple(self):
         for expr, parameters, expected in eval_simple:
             result = self.evaluate(expr, parameters)
             self.assertEqual(result, expected)
 
-    def test_eval_many_arguments(self, expected_exception=SyntaxError):
-        with self.assertRaises(expected_exception):
-            for expr, parameters, expected in eval_many_arguments:
-                result = self.evaluate(expr, parameters)
-                self.assertEqual(result, expected)
+    def test_eval_many_arguments(self):
+        for expr, parameters, expected in eval_many_arguments:
+            result = self.evaluate(expr, parameters)
+            self.assertEqual(result, expected)
 
     def test_eval_simple_functions(self):
         for expr, parameters, expected in eval_simple_functions:
@@ -278,7 +272,22 @@ class EvaluationTests(TestCase):
             np.testing.assert_equal(result, expected)
 
 
-class CompiledEvaluationTest(EvaluationTests):
+class LamdifiedEvaluationTest(EvaluationTestsBase, unittest.TestCase):
+
+    def evaluate(self, expression: Union[sympy.Expr, np.ndarray], parameters):
+        if isinstance(expression, np.ndarray):
+            variables = set.union(*map(set, map(get_variables, expression.flat)))
+        else:
+            variables = get_variables(expression)
+        return evaluate_lambdified(expression, variables=list(variables), parameters=parameters, lambdified=None)[0]
+
+    @unittest.skipIf(sys.version_info[0] == 3 and sys.version_info[1] < 7, "causes syntax error for python < 3.7")
+    def test_eval_many_arguments(self):
+        super().test_eval_many_arguments()
+
+
+class CompiledEvaluationTest(EvaluationTestsBase, unittest.TestCase):
+
     def evaluate(self, expression: Union[sympy.Expr, np.ndarray], parameters):
         if isinstance(expression, np.ndarray):
             return self.evaluate(sympy.Array(expression), parameters)
@@ -291,7 +300,7 @@ class CompiledEvaluationTest(EvaluationTests):
             return result
 
     def test_eval_many_arguments(self):
-        super().test_eval_many_arguments(None)
+        super().test_eval_many_arguments()
 
 
 class RepresentationTest(unittest.TestCase):


### PR DESCRIPTION
Recently tests where failing for python 3.4 environment on travis.
We where using miniconda on travis to install gmpy2 more easily. `conda install gmpy2` caused conda to update python to version 3.7 on this environment which in turn caused some test expecting a SyntaxError to fail because that SyntaxError wasn't raised anymore (my guess is that until recently either conda did only update the python version to 3.6).
Trying to fix this surfaced two more issues:
- dependencies in requirements.txt where not available in python 3.4
- a lot of SyntaxErrors in regular parts of code with python 3.4

I made the following changes:
- Dropped official support for 3.4 in setup.py as our code is not compatible
- Fixed problems tests had with python 3.7 and added travis test configuration
- Completely removed usage of conda during tests on travis. For tests we need to be able to configure exactly what environment the tests are executed in. If miniconda changes this in the background, it's not useful.
- No longer installing requirements.txt in travis tests. The travis.yml is configured so that different configurations of extras (as defined in setup.py) are tested (e.g., native types vs gmpy2 for faster/more precise arithmetics). Installing all requirements from requirements.txt beforehand defeats the purpose of this. (this does, however, open us up to the issue of dependencies becoming incompatible in future updates, for which I don't have a nice solution yet)