### PR TITLE
allow ExpressionScalar to be used in f-strings

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,9 @@
         - `allow_partial_parameter_mapping` is now True as a default. The default can be changed with the class variable `MappingPulseTemplate.ALLOW_PARTIAL_PARAMETER_MAPPING`.
         - Add specializations for `map_parameters` because the auto-inference of the return type did not work for empty input.
 
+- Expressions:
+    - Expressions can now be formatted as floats if they do not have free variables
+
 ## 0.4 ##
 
 - General:

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -240,6 +240,11 @@ class ExpressionScalar(Expression):
     def __repr__(self) -> str:
         return 'Expression({})'.format(repr(self._original_expression))
 
+    def __format__(self, format_spec):
+        if format_spec=='':
+            return str(self)
+        return f'%{format_spec}' % float(self)
+    
     @property
     def variables(self) -> Sequence[str]:
         return self._variables

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -241,9 +241,9 @@ class ExpressionScalar(Expression):
         return 'Expression({})'.format(repr(self._original_expression))
 
     def __format__(self, format_spec):
-        if format_spec=='':
+        if format_spec == '':
             return str(self)
-        return f'%{format_spec}' % float(self)
+        return format(float(self), format_spec)
     
     @property
     def variables(self) -> Sequence[str]:

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -103,6 +103,12 @@ class ExpressionVectorTests(unittest.TestCase):
 
 
 class ExpressionScalarTests(unittest.TestCase):
+    
+    def test_fstring(self) -> None:
+        e = ExpressionScalar('2.0')
+        self.assertEqual( f'{e}', str(e) )
+        self.assertEqual( f'{e:.2f}', '%.2f' % e) 
+        
     def test_evaluate_numeric(self) -> None:
         e = ExpressionScalar('a * b + c')
         params = {

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 import numpy as np
 from sympy import sympify, Eq
@@ -103,11 +104,29 @@ class ExpressionVectorTests(unittest.TestCase):
 
 
 class ExpressionScalarTests(unittest.TestCase):
-    
+    def test_format(self):
+        expr = ExpressionScalar('17')
+        e_format = '{:.4e}'.format(expr)
+        self.assertEqual(e_format, "1.7000e+01")
+
+        empty_format = "{}".format(expr)
+        self.assertEqual(empty_format, '17')
+
+        expr_with_var = ExpressionScalar('17*a')
+        with self.assertRaises(TypeError):
+            # throw error on implicit float cast
+            '{:.4e}'.format(expr_with_var)
+
+        empty_format = "{}".format(expr_with_var)
+        self.assertEqual(empty_format, '17*a')
+
+    @unittest.skipIf(sys.version_info < (3, 6), "format string literals require 3.6 or higher")
     def test_fstring(self) -> None:
-        e = ExpressionScalar('2.0')
-        self.assertEqual( f'{e}', str(e) )
-        self.assertEqual( f'{e:.2f}', '%.2f' % e) 
+        src_code = """e = ExpressionScalar('2.0'); \
+        self.assertEqual( f'{e}', str(e) ); \
+        self.assertEqual( f'{e:.2f}', '%.2f' % e)
+        """
+        exec(src_code)
         
     def test_evaluate_numeric(self) -> None:
         e = ExpressionScalar('a * b + c')


### PR DESCRIPTION
We might have to discuss what is the desired behaviour for f-strings, but it seems reasonable to allow printing as a floating point number.

We also need to disable tests for python 3.5. Any preferred way to do this?

@terrorfisch 