### PR TITLE
Fix bugs in Tektronix driver

### DIFF
--- a/qupulse/hardware/awgs/tektronix.py
+++ b/qupulse/hardware/awgs/tektronix.py
@@ -109,12 +109,14 @@ def parse_program(program: Loop,
                                                               Sequence[tek_awg.Waveform]]:
     """Convert the program into a sequence of sequence table entries and a sequence of waveforms that can be uploaded
     to the device."""
-    assert program.depth() == 1, "Invalid program depth."
-    assert program.repetition_count == 1, "Cannot repeat program a finite number of times (only once)"
+    assert program.depth() == 1, ("Invalid program depth: %d" % program.depth())
+    assert program.repetition_count == 1, ("Cannot repeat program a finite number of times (only once not %d)" %
+                                           program.repetition_count)
 
     # For backward compatibility
+    # EDIT: I think this is not needed? (Simon)
     if offsets is None:
-        offsets = tuple(np.zeros(len(amplitudes)))
+        offsets = (0.,) * len(amplitudes)
 
     assert len(channels) == len(markers) == len(amplitudes) == len(voltage_transformations) == len(offsets)
 

--- a/qupulse/hardware/awgs/tektronix.py
+++ b/qupulse/hardware/awgs/tektronix.py
@@ -550,7 +550,25 @@ class TektronixAWG(AWG):
             new_entries = []
 
             for entry in entries:
-                if isinstance(entry, int):
+                if isinstance(entry, str):
+                    # check that we know the waveform
+                    wf_name = self._waveforms.by_name[entry].name
+
+                elif isinstance(entry, tek_awg.Waveform):
+                    if entry in self._waveforms.by_data:
+                        wf_name = self._waveforms.by_data[entry].name
+
+                    elif entry in waveforms_to_upload:
+                        wf_name = waveforms_to_upload[entry]
+
+                    else:
+                        wf_name = name + '_' + str(abs(hash(entry)))
+                        waveforms_to_upload[entry] = wf_name
+
+                else:
+                    assert entry - int(entry) == 0
+                    entry = int(entry)
+
                     if entry in required_idle_pulses:
                         wf_name = required_idle_pulses[entry]
 
@@ -566,21 +584,6 @@ class TektronixAWG(AWG):
                             waveforms_to_upload[wf_data] = wf_name
 
                         required_idle_pulses[entry] = wf_name
-
-                elif isinstance(entry, tek_awg.Waveform):
-                    if entry in self._waveforms.by_data:
-                        wf_name = self._waveforms.by_data[entry].name
-
-                    elif entry in waveforms_to_upload:
-                        wf_name = waveforms_to_upload[entry]
-
-                    else:
-                        wf_name = name + '_' + str(abs(hash(entry)))
-                        waveforms_to_upload[entry] = wf_name
-
-                else:
-                    # check that we know the waveform
-                    wf_name = self._waveforms.by_name[entry].name
 
                 new_entries.append(wf_name)
 

--- a/qupulse/hardware/awgs/tektronix.py
+++ b/qupulse/hardware/awgs/tektronix.py
@@ -733,7 +733,7 @@ class TektronixAWG(AWG):
             self.device.set_seq_length(len(self._sequence_entries) + len(missing))
             self._sequence_entries.extend(itertools.repeat(None, len(missing)))
             free_positions.extend(missing)
-        return free_positions
+        return free_positions[:length]
 
     def _delete_waveform(self, waveform_name: str):
         self.device.del_waveform(waveform_name)

--- a/tests/hardware/tektronix_tests.py
+++ b/tests/hardware/tektronix_tests.py
@@ -375,7 +375,7 @@ class TektronixAWGTests(unittest.TestCase):
             results = awg._get_empty_sequence_positions(2)
 
             set_seq_length_mock.assert_not_called()
-            assert_synced_mock.assert_called_once()
+            assert_synced_mock.assert_called_once_with()
         self.assertEqual([0, None, 1, None, 2, None, 3], awg._sequence_entries)
         self.assertEqual([2, 4], results)
 
@@ -384,7 +384,7 @@ class TektronixAWGTests(unittest.TestCase):
             results = awg._get_empty_sequence_positions(3)
 
             set_seq_length_mock.assert_not_called()
-            assert_synced_mock.assert_called_once()
+            assert_synced_mock.assert_called_once_with()
         self.assertEqual([0, None, 1, None, 2, None, 3], awg._sequence_entries)
         self.assertEqual([2, 4, 6], results)
 
@@ -393,6 +393,6 @@ class TektronixAWGTests(unittest.TestCase):
             results = awg._get_empty_sequence_positions(6)
 
             set_seq_length_mock.assert_called_once_with(10)
-            assert_synced_mock.assert_called_once()
+            assert_synced_mock.assert_called_once_with()
         self.assertEqual([0, None, 1, None, 2, None, 3, None, None, None], awg._sequence_entries)
         self.assertEqual([2, 4, 6, 8, 9, 10], results)


### PR DESCRIPTION
 - isinstance(entry, int) in line _process_program does now handle arbitrary integer types
- `_get_empty_sequence_positions` now returns only as much free positions as asked for (+ tests)