### PR TITLE
Convert duration with full precision

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,8 @@
 ## pending/current ##
 
+ - General:
+   - Improve `TimeType` consistency by leveraging str(float) for rounding by default.
+
  - Hardware:
    - Add a `measure_program` method to the DAC interface. This method is used by the QCoDeS integration.
    - Add a `set_measurement_mask` to DAC interface. This method is used by the QCoDeS integration.

--- a/qupulse/_program/waveforms.py
+++ b/qupulse/_program/waveforms.py
@@ -201,7 +201,7 @@ class TableWaveform(Waveform):
 
     @property
     def duration(self) -> TimeType:
-        return time_from_float(self._table[-1].t, 0)
+        return TimeType.from_float(self._table[-1].t)
 
     def unsafe_sample(self,
                       channel: ChannelID,
@@ -245,7 +245,7 @@ class FunctionWaveform(Waveform):
             raise ValueError('FunctionWaveforms may not depend on anything but "t"')
 
         self._expression = expression
-        self._duration = time_from_float(duration, 0)
+        self._duration = TimeType.from_float(duration)
         self._channel_id = channel
 
     @property

--- a/qupulse/_program/waveforms.py
+++ b/qupulse/_program/waveforms.py
@@ -201,7 +201,7 @@ class TableWaveform(Waveform):
 
     @property
     def duration(self) -> TimeType:
-        return time_from_float(self._table[-1].t)
+        return time_from_float(self._table[-1].t, 0)
 
     def unsafe_sample(self,
                       channel: ChannelID,
@@ -245,7 +245,7 @@ class FunctionWaveform(Waveform):
             raise ValueError('FunctionWaveforms may not depend on anything but "t"')
 
         self._expression = expression
-        self._duration = time_from_float(duration)
+        self._duration = time_from_float(duration, 0)
         self._channel_id = channel
 
     @property

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -15,6 +15,7 @@ import numpy
 from qupulse.serialization import AnonymousSerializable
 from qupulse.utils.sympy import sympify, to_numpy, recursive_substitution, evaluate_lambdified,\
     get_most_simple_representation, get_variables
+from qupulse.utils.types import TimeType
 
 __all__ = ["Expression", "ExpressionVariableMissingException", "ExpressionScalar", "ExpressionVector"]
 
@@ -45,7 +46,7 @@ class Expression(AnonymousSerializable, metaclass=_ExpressionMeta):
     def _parse_evaluate_numeric_result(self,
                                        result: Union[Number, numpy.ndarray],
                                        call_arguments: Any) -> Union[Number, numpy.ndarray]:
-        allowed_types = (float, numpy.number, int, complex, bool, numpy.bool_)
+        allowed_types = (float, numpy.number, int, complex, bool, numpy.bool_, TimeType)
         if isinstance(result, tuple):
             result = numpy.array(result)
         if isinstance(result, numpy.ndarray):
@@ -56,7 +57,7 @@ class Expression(AnonymousSerializable, metaclass=_ExpressionMeta):
                 if obj_types == {sympy.Float} or obj_types == {sympy.Float, sympy.Integer}:
                     return result.astype(float)
                 elif obj_types == {sympy.Integer}:
-                    return result.astype(np.int64)
+                    return result.astype(numpy.int64)
                 else:
                     raise NonNumericEvaluation(self, result, call_arguments)
         elif isinstance(result, allowed_types):

--- a/qupulse/hardware/dacs/alazar.py
+++ b/qupulse/hardware/dacs/alazar.py
@@ -116,7 +116,7 @@ class AlazarCard(DAC):
                                      program_name: str,
                                      windows: Dict[str, Tuple[np.ndarray, np.ndarray]]) -> None:
         program = self._registered_programs[program_name]
-        sample_factor = TimeType(int(self.config.captureClockConfiguration.numeric_sample_rate(self.card.model)),
+        sample_factor = TimeType.from_fraction(int(self.config.captureClockConfiguration.numeric_sample_rate(self.card.model)),
                                  10 ** 9)
         program.clear_masks()
 
@@ -133,7 +133,8 @@ class AlazarCard(DAC):
             config.masks, config.operations, total_record_size = self._registered_programs[program_name].iter(
                 self._make_mask)
 
-            sample_factor = TimeType(self.config.captureClockConfiguration.numeric_sample_rate(self.card.model), 10 ** 9)
+            sample_factor = TimeType.from_fraction(self.config.captureClockConfiguration.numeric_sample_rate(self.card.model),
+                                                   10 ** 9)
 
             if not config.operations:
                 raise RuntimeError("No operations: Arming program without operations is an error as there will "

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -34,7 +34,10 @@ except ImportError:
     TimeType = fractions.Fraction
 
     def time_from_float(time: float, absolute_error: float = 1e-12) -> TimeType:
-        return fractions.Fraction(time).limit_denominator(int(1/absolute_error))
+        if absolute_error > 0.:
+            return fractions.Fraction(time).limit_denominator(int(1/absolute_error))
+        else:
+            return fractions.Fraction(time)
 
     def time_from_fraction(numerator: int, denominator: int = 1) -> TimeType:
         return fractions.Fraction(numerator=numerator, denominator=denominator)

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -3,9 +3,7 @@ import abc
 import inspect
 import numbers
 import fractions
-import collections
-import itertools
-from collections.abc import Mapping as ABCMapping
+import functools
 import warnings
 
 import numpy
@@ -26,7 +24,8 @@ except ImportError:
 
 
 def _with_other_as_time_type(fn):
-    """This is decorator to convert the other argument into a TimeType"""
+    """This is decorator to convert the other argument and the result into a :class:`TimeType`"""
+    @functools.wraps(fn)
     def wrapper(self, other) -> 'TimeType':
         converted = _converter.get(type(other), TimeType)(other)
         result = fn(self, converted)
@@ -42,7 +41,7 @@ def _with_other_as_time_type(fn):
 class TimeType:
     """This type represents a rational number with arbitrary precision.
 
-    Internally it uses gmpy2.mpq (if available) or fractions.Fraction
+    Internally it uses :func:`gmpy2.mpq` (if available) or :class:`fractions.Fraction`
     """
     __slots__ = ('_value',)
 
@@ -198,6 +197,15 @@ class TimeType:
 
     @classmethod
     def from_fraction(cls, numerator: int, denominator: int) -> 'TimeType':
+        """
+
+        Args:
+            numerator: Numerator of the time fraction
+            denominator: Denominator of the time fraction
+
+        Returns:
+            A new TimeType object.
+        """
         return cls(cls._to_internal(numerator, denominator))
 
     def __repr__(self):
@@ -221,12 +229,12 @@ _converter = {
 
 
 def time_from_float(value: float, absolute_error: typing.Optional[float] = None) -> TimeType:
-    warnings.warn("time_from_float is deprecated. Use TimeType.from_float instead", DeprecationWarning)
+    """See :func:`TimeType.from_float`."""
     return TimeType.from_float(value, absolute_error)
 
 
 def time_from_fraction(numerator: int, denominator: int) -> TimeType:
-    warnings.warn("time_from_fraction is deprecated. Use TimeType.from_fraction instead", DeprecationWarning)
+    """See :func:`TimeType.from_float`."""
     return TimeType.from_fraction(numerator, denominator)
 
 

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -39,7 +39,7 @@ def _with_other_as_time_type(fn):
     return wrapper
 
 
-class TimeType(numbers.Rational):
+class TimeType:
     """This type represents a rational number with arbitrary precision.
 
     Internally it uses gmpy2.mpq (if available) or fractions.Fraction
@@ -76,6 +76,9 @@ class TimeType(numbers.Rational):
 
     def __floor__(self):
         return int(self._value.__floor__())
+
+    def __int__(self):
+        return self._value.__int__()
 
     @_with_other_as_time_type
     def __mod__(self, other: 'TimeType'):
@@ -201,6 +204,10 @@ class TimeType(numbers.Rational):
 
     def __float__(self):
         return int(self._value.numerator) / int(self._value.denominator)
+
+
+# this asserts isinstance(TimeType, Rational) is True
+numbers.Rational.register(TimeType)
 
 
 _converter = {

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -135,6 +135,15 @@ class TimeType:
 
     @classmethod
     def from_float(cls, value: float, absolute_error: typing.Optional[float] = None) -> 'TimeType':
+        """Convert a floating point number to a TimeType using one of three modes depending on `absolute_error`.
+
+        absolute_error is None: Use `str(value)` as a proxy to get consistent precision (see below)
+        absolute_error == 0: Return the exact value of the float. 0.8 == 3602879701896397 / 4503599627370496
+        else: Use absolute error to limit the denominator
+
+        str(value) guarantees that all floats have a different result with sensible rounding.this was chosen as a
+        default because it is the expected behaviour most of the time.
+        """
         # gmpy2 is at least an order of magnitude faster than fractions.Fraction
         if absolute_error is None:
             # this method utilizes the 'print as many digits as necessary to destinguish between all floats'

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -39,7 +39,7 @@ def _with_other_as_time_type(fn):
     return wrapper
 
 
-class TimeType:
+class TimeType(numbers.Rational):
     """This type represents a rational number with arbitrary precision.
 
     Internally it uses gmpy2.mpq (if available) or fractions.Fraction
@@ -62,14 +62,45 @@ class TimeType:
     def denominator(self):
         return self._value.denominator
 
-    def __round__(self):
-        return self._value.__round__()
+    def __round__(self, *args, **kwargs):
+        return self._value.__round__(*args, **kwargs)
 
     def __abs__(self):
-        return self._value.__abs__()
+        return TimeType(self._value.__abs__())
 
     def __hash__(self):
         return self._value.__hash__()
+
+    def __ceil__(self):
+        return int(self._value.__ceil__())
+
+    def __floor__(self):
+        return int(self._value.__floor__())
+
+    @_with_other_as_time_type
+    def __mod__(self, other: 'TimeType'):
+        return self._value.__mod__(other._value)
+
+    @_with_other_as_time_type
+    def __rmod__(self, other: 'TimeType'):
+        return self._value.__rmod__(other._value)
+
+    def __neg__(self):
+        return TimeType(self._value.__neg__())
+
+    def __pos__(self):
+        return self
+
+    @_with_other_as_time_type
+    def __pow__(self, other: 'TimeType'):
+        return self._value.__pow__(other._value)
+
+    @_with_other_as_time_type
+    def __rpow__(self, other: 'TimeType'):
+        return self._value.__rpow__(other._value)
+
+    def __trunc__(self):
+        return int(self._value.__trunc__())
 
     @_with_other_as_time_type
     def __mul__(self, other: 'TimeType'):

--- a/tests/_program/loop_tests.py
+++ b/tests/_program/loop_tests.py
@@ -4,7 +4,7 @@ import itertools
 
 from string import ascii_uppercase
 
-from qupulse.utils.types import time_from_float
+from qupulse.utils.types import TimeType
 from qupulse._program._loop import Loop, MultiChannelProgram, _make_compatible, _is_compatible, _CompatibilityLevel, RepetitionWaveform, SequenceWaveform, make_compatible
 from qupulse._program.instructions import InstructionBlock, ImmutableInstructionBlock
 from tests.pulses.sequencing_dummies import DummyWaveform
@@ -541,32 +541,32 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
     def test_is_compatible_incompatible(self):
         wf = DummyWaveform(duration=1.1)
 
-        self.assertEqual(_is_compatible(Loop(waveform=wf), min_len=1, quantum=1, sample_rate=time_from_float(1.)),
+        self.assertEqual(_is_compatible(Loop(waveform=wf), min_len=1, quantum=1, sample_rate=TimeType.from_float(1.)),
                          _CompatibilityLevel.incompatible)
 
-        self.assertEqual(_is_compatible(Loop(waveform=wf, repetition_count=10), min_len=20, quantum=1, sample_rate=time_from_float(1.)),
+        self.assertEqual(_is_compatible(Loop(waveform=wf, repetition_count=10), min_len=20, quantum=1, sample_rate=TimeType.from_float(1.)),
                          _CompatibilityLevel.incompatible)
 
-        self.assertEqual(_is_compatible(Loop(waveform=wf, repetition_count=10), min_len=10, quantum=3, sample_rate=time_from_float(1.)),
+        self.assertEqual(_is_compatible(Loop(waveform=wf, repetition_count=10), min_len=10, quantum=3, sample_rate=TimeType.from_float(1.)),
                          _CompatibilityLevel.incompatible)
 
     def test_is_compatible_leaf(self):
         self.assertEqual(_is_compatible(Loop(waveform=DummyWaveform(duration=1.1), repetition_count=10),
-                                        min_len=11, quantum=1, sample_rate=time_from_float(1.)),
+                                        min_len=11, quantum=1, sample_rate=TimeType.from_float(1.)),
                          _CompatibilityLevel.action_required)
 
         self.assertEqual(_is_compatible(Loop(waveform=DummyWaveform(duration=1.1), repetition_count=10),
-                                        min_len=11, quantum=1, sample_rate=time_from_float(10.)),
+                                        min_len=11, quantum=1, sample_rate=TimeType.from_float(10.)),
                          _CompatibilityLevel.compatible)
 
     def test_is_compatible_node(self):
         program = Loop(children=[Loop(waveform=DummyWaveform(duration=1.5), repetition_count=2),
                                  Loop(waveform=DummyWaveform(duration=2.0))])
 
-        self.assertEqual(_is_compatible(program, min_len=1, quantum=1, sample_rate=time_from_float(2.)),
+        self.assertEqual(_is_compatible(program, min_len=1, quantum=1, sample_rate=TimeType.from_float(2.)),
                          _CompatibilityLevel.compatible)
 
-        self.assertEqual(_is_compatible(program, min_len=1, quantum=1, sample_rate=time_from_float(1.)),
+        self.assertEqual(_is_compatible(program, min_len=1, quantum=1, sample_rate=TimeType.from_float(1.)),
                          _CompatibilityLevel.action_required)
 
     def test_make_compatible_partial_unroll(self):
@@ -576,7 +576,7 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
         program = Loop(children=[Loop(waveform=wf1, repetition_count=2),
                                  Loop(waveform=wf2)])
 
-        _make_compatible(program, min_len=1, quantum=1, sample_rate=time_from_float(1.))
+        _make_compatible(program, min_len=1, quantum=1, sample_rate=TimeType.from_float(1.))
 
         self.assertIsNone(program.waveform)
         self.assertEqual(len(program), 2)
@@ -587,7 +587,7 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
 
         program = Loop(children=[Loop(waveform=wf1, repetition_count=2),
                                  Loop(waveform=wf2)], repetition_count=2)
-        _make_compatible(program, min_len=5, quantum=1, sample_rate=time_from_float(1.))
+        _make_compatible(program, min_len=5, quantum=1, sample_rate=TimeType.from_float(1.))
 
         self.assertIsInstance(program.waveform, SequenceWaveform)
         self.assertEqual(program.children, [])
@@ -606,7 +606,7 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
         program = Loop(children=[Loop(waveform=wf1, repetition_count=2),
                                  Loop(waveform=wf2, repetition_count=1)], repetition_count=2)
 
-        _make_compatible(program, min_len=5, quantum=10, sample_rate=time_from_float(1.))
+        _make_compatible(program, min_len=5, quantum=10, sample_rate=TimeType.from_float(1.))
 
         self.assertIsInstance(program.waveform, RepetitionWaveform)
         self.assertEqual(program.children, [])
@@ -626,8 +626,8 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
         program = Loop()
         pub_kwargs = dict(minimal_waveform_length=5,
                           waveform_quantum=10,
-                          sample_rate=time_from_float(1.))
-        priv_kwargs = dict(min_len=5, quantum=10, sample_rate=time_from_float(1.))
+                          sample_rate=TimeType.from_float(1.))
+        priv_kwargs = dict(min_len=5, quantum=10, sample_rate=TimeType.from_float(1.))
 
         with mock.patch('qupulse._program._loop._is_compatible',
                         return_value=_CompatibilityLevel.incompatible) as mocked:

--- a/tests/_program/waveforms_tests.py
+++ b/tests/_program/waveforms_tests.py
@@ -4,7 +4,7 @@ from unittest import mock
 import numpy
 import numpy as np
 
-from qupulse.utils.types import time_from_float
+from qupulse.utils.types import TimeType
 from qupulse.pulses.interpolation import HoldInterpolationStrategy, LinearInterpolationStrategy,\
     JumpInterpolationStrategy
 from qupulse._program.waveforms import MultiChannelWaveform, RepetitionWaveform, SequenceWaveform,\
@@ -117,7 +117,7 @@ class MultiChannelWaveformTest(unittest.TestCase):
 
         waveform = MultiChannelWaveform([dwf])
         self.assertEqual({'A'}, waveform.defined_channels)
-        self.assertEqual(time_from_float(1.3), waveform.duration)
+        self.assertEqual(TimeType.from_float(1.3), waveform.duration)
 
     def test_init_several_channels(self) -> None:
         dwf_a = DummyWaveform(duration=2.2, defined_channels={'A'})
@@ -126,7 +126,7 @@ class MultiChannelWaveformTest(unittest.TestCase):
 
         waveform = MultiChannelWaveform([dwf_a, dwf_b])
         self.assertEqual({'A', 'B'}, waveform.defined_channels)
-        self.assertEqual(time_from_float(2.2), waveform.duration)
+        self.assertEqual(TimeType.from_float(2.2), waveform.duration)
 
         with self.assertRaises(ValueError):
             MultiChannelWaveform([dwf_a, dwf_c])
@@ -224,7 +224,7 @@ class RepetitionWaveformTest(unittest.TestCase):
 
     def test_duration(self):
         wf = RepetitionWaveform(DummyWaveform(duration=2.2), 3)
-        self.assertEqual(wf.duration, time_from_float(2.2)*3)
+        self.assertEqual(wf.duration, TimeType.from_float(2.2)*3)
 
     def test_defined_channels(self):
         body_wf = DummyWaveform(defined_channels={'a'})
@@ -333,8 +333,8 @@ class SequenceWaveformTest(unittest.TestCase):
         self.assertEqual(sub_wf.compare_key[0].defined_channels, subset)
         self.assertEqual(sub_wf.compare_key[1].defined_channels, subset)
 
-        self.assertEqual(sub_wf.compare_key[0].duration, time_from_float(2.2))
-        self.assertEqual(sub_wf.compare_key[1].duration, time_from_float(3.3))
+        self.assertEqual(sub_wf.compare_key[0].duration, TimeType.from_float(2.2))
+        self.assertEqual(sub_wf.compare_key[1].duration, TimeType.from_float(3.3))
 
 
 

--- a/tests/hardware/alazar_tests.py
+++ b/tests/hardware/alazar_tests.py
@@ -17,7 +17,7 @@ class AlazarProgramTest(unittest.TestCase):
             'sorted': (np.array([30., 100, 1300]), np.array([10., 990, 811])),
             'overlapping': (np.array([30., 100, 300]), np.array([20., 900, 100]))
         }
-        self.sample_factor = TimeType(10**8, 10**9)
+        self.sample_factor = TimeType.from_fraction(10**8, 10**9)
         self.expected = {
             'unsorted': (np.array([0, 1, 10]).astype(np.uint64), np.array([1, 8, 99]).astype(np.uint64)),
             'sorted': (np.array([3, 10, 130]).astype(np.uint64), np.array([1, 99, 81]).astype(np.uint64)),

--- a/tests/hardware/tektronix_tests.py
+++ b/tests/hardware/tektronix_tests.py
@@ -130,7 +130,7 @@ class TektronixProgramTests(unittest.TestCase):
                      np.array([0., -.1, -.2, 0.]),
                      np.array([0., 0, 0, 1.])]
 
-        sample_rate_in_GHz = TimeType(1, 2)
+        sample_rate_in_GHz = TimeType.from_fraction(1, 2)
 
         # channel A is the same in wfs_6[1] and wfs_6[2]
         wfs_6 = [DummyWaveform(duration=12, sample_output={'A':  sampled_6[0],

--- a/tests/hardware/util_tests.py
+++ b/tests/hardware/util_tests.py
@@ -179,10 +179,10 @@ class FindPositionTest(unittest.TestCase):
 
 class SampleTimeCalculationTest(unittest.TestCase):
     def test_get_sample_times(self):
-        sample_rate = TimeType(12, 10)
-        wf1 = DummyWaveform(duration=TimeType(20, 12))
-        wf2 = DummyWaveform(duration=TimeType(400000000001, 120000000000))
-        wf3 = DummyWaveform(duration=TimeType(1, 10**15))
+        sample_rate = TimeType.from_fraction(12, 10)
+        wf1 = DummyWaveform(duration=TimeType.from_fraction(20, 12))
+        wf2 = DummyWaveform(duration=TimeType.from_fraction(400000000001, 120000000000))
+        wf3 = DummyWaveform(duration=TimeType.from_fraction(1, 10**15))
 
         expected_times = np.arange(4) / 1.2
         times, n_samples = get_sample_times([wf1, wf2], sample_rate_in_GHz=sample_rate)
@@ -199,8 +199,8 @@ class SampleTimeCalculationTest(unittest.TestCase):
             get_sample_times([wf1, wf3], sample_rate_in_GHz=sample_rate)
 
     def test_get_sample_times_single_wf(self):
-        sample_rate = TimeType(12, 10)
-        wf = DummyWaveform(duration=TimeType(40, 12))
+        sample_rate = TimeType.from_fraction(12, 10)
+        wf = DummyWaveform(duration=TimeType.from_fraction(40, 12))
 
         expected_times = np.arange(4) / 1.2
         times, n_samples = get_sample_times(wf, sample_rate_in_GHz=sample_rate)

--- a/tests/pulses/function_pulse_tests.py
+++ b/tests/pulses/function_pulse_tests.py
@@ -2,7 +2,7 @@ import unittest
 import sympy
 import numpy as np
 
-from qupulse.utils.types import time_from_float
+from qupulse.utils.types import TimeType
 from qupulse.pulses.function_pulse_template import FunctionPulseTemplate,\
     FunctionWaveform
 from qupulse.serialization import Serializer, Serializable, PulseStorage

--- a/tests/pulses/function_pulse_tests.py
+++ b/tests/pulses/function_pulse_tests.py
@@ -239,7 +239,7 @@ class FunctionWaveformTest(unittest.TestCase):
     def test_duration(self) -> None:
         wf = FunctionWaveform(expression=Expression('2*t'), duration=4/5,
                               channel='A')
-        self.assertEqual(time_from_float(4/5), wf.duration)
+        self.assertEqual(TimeType.from_float(4/5), wf.duration)
 
     def test_unsafe_sample(self):
         fw = FunctionWaveform(Expression('sin(2*pi*t) + 3'), 5, channel='A')

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -1,10 +1,8 @@
 import unittest
 from unittest import mock
-import warnings
 
 import numpy
 
-from qupulse.utils.types import time_from_float
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform, MappingPulseTemplate,\
     ChannelMappingException, AtomicMultiChannelPulseTemplate, ParallelConstantChannelPulseTemplate,\
     TransformingWaveform, ParallelConstantChannelTransformation

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -150,7 +150,7 @@ class DummyWaveform(Waveform):
 
     def __init__(self, duration: float=0, sample_output: Union[numpy.ndarray, dict]=None, defined_channels={'A'}) -> None:
         super().__init__()
-        self.duration_ = time_from_float(duration)
+        self.duration_ = TimeType.from_float(duration)
         self.sample_output = sample_output
         self.defined_channels_ = defined_channels
         self.sample_calls = []

--- a/tests/utils/time_type_tests.py
+++ b/tests/utils/time_type_tests.py
@@ -94,13 +94,6 @@ class TestTimeType(unittest.TestCase):
     def test_fraction_time_from_float_with_precision_fallback(self):
         self.assert_fraction_time_from_float_with_precision_works(self.fallback_qutypes.TimeType)
 
-    def test_deprecation_warnings(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(qutypes.time_from_float(1.), 1)
-
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(qutypes.time_from_fraction(2, 3), fractions.Fraction(2, 3))
-
     def assert_from_float_no_extra_args_works(self, time_type):
         # test that float(from_float(x)) == x
         base_floats = [4/5, 1, 1000, 0, np.pi, 1.23456789**99, 1e-100, 2**53]

--- a/tests/utils/time_type_tests.py
+++ b/tests/utils/time_type_tests.py
@@ -125,6 +125,13 @@ class TestTimeType(unittest.TestCase):
     def test_from_float_no_extra_args_fallback(self):
         self.assert_from_float_exact_works(self.fallback_qutypes.TimeType)
 
+    def test_from_float_exceptions(self):
+        with self.assertRaisesRegex(ValueError, 'at least 0'):
+            qutypes.time_from_float(.8, -1)
+
+        with self.assertRaisesRegex(ValueError, 'smaller 1'):
+            qutypes.time_from_float(.8, 2)
+
 
 def get_some_floats(seed=42, n=1000):
     rand = random.Random(seed)


### PR DESCRIPTION
This pull request fixes a duration value change (#475 ) when converting it from `float` to `TimeType`(arbitrary precision via fractions) by abusing `float` to `str` to get a consistent rounding.

This might lead to unexpected consequences due to float rounding errors with fractional times.

TODO:

- [x] Add more test cases
- [x] Quantify performance impact

I think the factor 2 worse performance (with gmpy) is worth the improved ergonomics.

@eendebakpt 