### PR TITLE
More repr implementations

### DIFF
--- a/qupulse/pulses/parameters.py
+++ b/qupulse/pulses/parameters.py
@@ -193,7 +193,7 @@ class ParameterConstraint(AnonymousSerializable):
             return str(self._expression.sympified_expression)
 
     def __repr__(self):
-        return 'ParameterConstraint(%s)' % self
+        return 'ParameterConstraint(%s)' % repr(str(self))
 
     def get_serialization_data(self) -> str:
         return str(self)

--- a/qupulse/pulses/parameters.py
+++ b/qupulse/pulses/parameters.py
@@ -192,6 +192,9 @@ class ParameterConstraint(AnonymousSerializable):
         else:
             return str(self._expression.sympified_expression)
 
+    def __repr__(self):
+        return 'ParameterConstraint(%s)' % self
+
     def get_serialization_data(self) -> str:
         return str(self)
 

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -229,9 +229,10 @@ class PulseTemplate(Serializable, SequencingElement, metaclass=DocStringABCMeta)
             value = getattr(self, attr)
             if value is None:
                 continue
-            formatted.append('{attr}={value}'.format(attr=attr, value=value))
+            # the repr(str(value)) is to avoid very deep nesting. If needed one should use repr
+            formatted.append('{attr}={value}'.format(attr=attr, value=repr(str(value))))
         type_name = type(self).__name__
-        return '{type_name}({attrs})'.format(type_name=type_name, attrs=','.join(formatted))
+        return '{type_name}({attrs})'.format(type_name=type_name, attrs=', '.join(formatted))
 
     def __str__(self):
         return format(self)

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -45,6 +45,9 @@ class PulseTemplate(Serializable, SequencingElement, metaclass=DocStringABCMeta)
     called instantiation of the PulseTemplate and achieved by invoking the sequencing process.
     """
 
+    """This is not stable"""
+    _DEFAULT_FORMAT_SPEC = 'identifier'
+
     def __init__(self, *,
                  identifier: Optional[str]) -> None:
         super().__init__(identifier=identifier)
@@ -217,6 +220,28 @@ class PulseTemplate(Serializable, SequencingElement, metaclass=DocStringABCMeta)
                                           to_single_waveform=to_single_waveform,
                                           global_transformation=global_transformation,
                                           parent_loop=parent_loop)
+
+    def __format__(self, format_spec: str):
+        if format_spec == '':
+            format_spec = self._DEFAULT_FORMAT_SPEC
+        formatted = []
+        for attr in format_spec.split(';'):
+            value = getattr(self, attr)
+            if value is None:
+                continue
+            formatted.append('{attr}={value}'.format(attr=attr, value=value))
+        type_name = type(self).__name__
+        return '{type_name}({attrs})'.format(type_name=type_name, attrs=','.join(formatted))
+
+    def __str__(self):
+        return format(self)
+
+    def __repr__(self):
+        type_name = type(self).__name__
+        kwargs = ','.join('%s=%r' % (key, value)
+                          for key, value in self.get_serialization_data().items()
+                          if key.isidentifier() and value is not None)
+        return '{type_name}({kwargs})'.format(type_name=type_name, kwargs=kwargs)
 
 
 class AtomicPulseTemplate(PulseTemplate, MeasurementDefiner):

--- a/tests/pulses/parameters_tests.py
+++ b/tests/pulses/parameters_tests.py
@@ -114,6 +114,10 @@ class ParameterConstraintTest(unittest.TestCase):
         self.assertEqual(str(ParameterConstraint('a==b')), 'a==b')
         self.assertEqual(ParameterConstraint('a==b').get_serialization_data(), 'a==b')
 
+    def test_repr(self):
+        pc = ParameterConstraint('a < b')
+        self.assertEqual("ParameterConstraint('a < b')", repr(pc))
+
 
 class ParameterNotProvidedExceptionTests(unittest.TestCase):
 

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -355,7 +355,7 @@ class PulseTemplateTest(unittest.TestCase):
         a = PulseTemplateStub(identifier='asd', duration=Expression(5))
         self.assertEqual("PulseTemplateStub(identifier='asd')", str(a))
         self.assertEqual("PulseTemplateStub(identifier='asd')", format(a))
-        self.assertEqual("PulseTemplateStub(identifier='asd', duration=Expression(5))",
+        self.assertEqual("PulseTemplateStub(identifier='asd', duration='5')",
                          "{:identifier;duration}".format(a))
 
 

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -351,6 +351,13 @@ class PulseTemplateTest(unittest.TestCase):
             self.assertEqual(b @ a, 'concat')
             mock_concatenate.assert_called_once_with(b, a)
 
+    def test_format(self):
+        a = PulseTemplateStub(identifier='asd', duration=Expression(5))
+        self.assertEqual("PulseTemplateStub(identifier='asd')", str(a))
+        self.assertEqual("PulseTemplateStub(identifier='asd')", format(a))
+        self.assertEqual("PulseTemplateStub(identifier='asd', duration=Expression(5))",
+                         "{:identifier;duration}".format(a))
+
 
 class AtomicPulseTemplateTests(unittest.TestCase):
 


### PR DESCRIPTION
- Add `__repr__` to ParameterConstraint
- Add `__repr__`, `__format__` and `__str__` to `PulseTemplate`

closes #477

TODO:
 - [x] Add tests