### PR TITLE
Add support for sympy 1.5

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 
  - General:
    - Improve `TimeType` consistency by leveraging str(float) for rounding by default.
+   - Add support for sympy==1.5
 
  - Hardware:
    - Add a `measure_program` method to the DAC interface. This method is used by the QCoDeS integration.

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -272,6 +272,8 @@ class ExpressionScalar(Expression):
 
     def __eq__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> bool:
         """Enable comparisons with Numbers"""
+        # sympy's __eq__ checks for structural equality to be consistent regarding __hash__ so we do that too
+        # see https://github.com/sympy/sympy/issues/18054#issuecomment-566198899
         return self._sympified_expression == self._sympify(other)
 
     def __hash__(self) -> int:

--- a/qupulse/utils/sympy.py
+++ b/qupulse/utils/sympy.py
@@ -26,10 +26,11 @@ __all__ = ["sympify", "substitute_with_eval", "to_numpy", "get_variables", "get_
 Sympifyable = Union[str, Number, sympy.Expr, numpy.str_]
 
 
-class IndexedBasedFinder:
+class IndexedBasedFinder(dict):
     """Acts as a symbol lookup and determines which symbols in an expression a subscripted."""
 
     def __init__(self):
+        super().__init__()
         self.symbols = set()
         self.indexed_base = set()
         self.indices = set()
@@ -46,6 +47,13 @@ class IndexedBasedFinder:
 
         self.SubscriptionChecker = SubscriptionChecker
 
+        def unimplementded(*args, **kwargs):
+            raise NotImplementedError("Not a full dict")
+
+        for m in vars(dict).keys():
+            if not m.startswith('_'):
+                setattr(self, m, unimplementded)
+
     def __getitem__(self, k) -> sympy.Expr:
         """Return an instance of the internal SubscriptionChecker class for each symbol to determine which symbols are
         indexed/subscripted.
@@ -60,6 +68,12 @@ class IndexedBasedFinder:
         # otherwise track the symbol name and return a SubscriptionChecker instance
         self.symbols.add(k)
         return self.SubscriptionChecker(k)
+
+    def __setitem__(self, key, value):
+        raise NotImplementedError("Not a full dict")
+
+    def __delitem__(self, key):
+        raise NotImplementedError("Not a full dict")
 
     def __contains__(self, k) -> bool:
         return True

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='qupulse',
           'tektronix': 'tek_awg>=0.2.1'
       },
       test_suite="tests",
-      tests_require=['pytest_benchmark'],
+      tests_require=['pytest_benchmark', 'distutils'],
       classifiers=[
           "Programming Language :: Python :: 3",
           "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='qupulse',
           'tektronix': 'tek_awg>=0.2.1'
       },
       test_suite="tests",
-      tests_require=['pytest_benchmark', 'distutils'],
+      tests_require=['pytest_benchmark'],
       classifiers=[
           "Programming Language :: Python :: 3",
           "License :: OSI Approved :: MIT License",

--- a/tests/pulses/table_pulse_template_tests.py
+++ b/tests/pulses/table_pulse_template_tests.py
@@ -424,9 +424,11 @@ class TablePulseTemplateTest(unittest.TestCase):
         pulse = TablePulseTemplate(entries={0: [(1, 2, 'linear'), (3, 0, 'jump'), (4, 2, 'hold'), (5, 8, 'hold')],
                                             'other_channel': [(0, 7, 'linear'), (2, 0, 'hold'), (10, 0)],
                                             'symbolic': [(3, 'a', 'hold'), ('b', 4, 'linear'), ('c', Expression('d'), 'hold')]})
-        self.assertEqual(pulse.integral, {0: Expression('6'),
-                                          'other_channel': Expression(7),
-                                          'symbolic': Expression('(b-3)*a + (c-b)*(d+4) / 2')})
+        expected = {0: Expression('6'),
+                    'other_channel': Expression(7),
+                    'symbolic': Expression('(b-3.)*a + (c-b)*(d+4.) / 2')}
+
+        self.assertEqual(expected, pulse.integral)
 
 
 class TablePulseTemplateConstraintTest(ParameterConstrainerTest):

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -2,6 +2,7 @@ import unittest
 import contextlib
 import math
 import sys
+from packaging import version
 
 from typing import Union
 
@@ -411,6 +412,22 @@ class BroadcastTests(unittest.TestCase):
 
         sympification = qc_sympify('Broadcast(a, (3,))')
         self.assertEqual(sympification, symbolic)
+
+    def test_expression_equality(self):
+        """Sympy decided to change their equality reasoning"""
+        self.assertEqual(sympy.sympify('3'), sympy.sympify('3.'))
+        self.assertEqual(sympy.sympify('3 + a'), sympy.sympify('3 + a'))
+        self.assertEqual(sympy.sympify('3 + a'), sympy.sympify('3. + a'))
+
+        expr_with_float = sympy.sympify('a*(b - 3.0) + (-b + c)*(d + 4.0)/2')
+        expr_with_int = sympy.sympify('a*(b - 3) + (-b + c)*(d + 4)/2')
+        expr_with_int_other_order = sympy.sympify('(b-3)*a + (c-b)*(d+4) / 2')
+
+        self.assertEqual(expr_with_float, expr_with_int)
+        self.assertEqual(expr_with_int, expr_with_int_other_order)
+        self.assertEqual(expr_with_float, expr_with_int_other_order)
+
+    test_numeric_equal = unittest.expectedFailure(test_expression_equality) if version.parse(sympy.__version__) >= version.parse('1.5') else test_expression_equality
 
 
 class IndexedBasedFinderTests(unittest.TestCase):

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -2,7 +2,7 @@ import unittest
 import contextlib
 import math
 import sys
-from packaging import version
+import distutils
 
 from typing import Union
 
@@ -427,7 +427,7 @@ class BroadcastTests(unittest.TestCase):
         self.assertEqual(expr_with_int, expr_with_int_other_order)
         self.assertEqual(expr_with_float, expr_with_int_other_order)
 
-    test_numeric_equal = unittest.expectedFailure(test_expression_equality) if version.parse(sympy.__version__) >= version.parse('1.5') else test_expression_equality
+    test_numeric_equal = unittest.expectedFailure(test_expression_equality) if distutils.version.StrictVersion(sympy.__version__) >= distutils.version.StrictVersion('1.5') else test_expression_equality
 
 
 class IndexedBasedFinderTests(unittest.TestCase):

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -16,7 +16,7 @@ b_ = IndexedBase(b)
 
 from qupulse.utils.sympy import sympify as qc_sympify, substitute_with_eval, recursive_substitution, Len,\
     evaluate_lambdified, evaluate_compiled, get_most_simple_representation, get_variables, get_free_symbols,\
-    almost_equal, Broadcast
+    almost_equal, Broadcast, IndexedBasedFinder
 
 
 ################################################### SUBSTITUTION #######################################################
@@ -412,3 +412,17 @@ class BroadcastTests(unittest.TestCase):
         sympification = qc_sympify('Broadcast(a, (3,))')
         self.assertEqual(sympification, symbolic)
 
+
+class IndexedBasedFinderTests(unittest.TestCase):
+    def test_isinstance(self):
+        self.assertIsInstance(IndexedBasedFinder(), dict)
+
+    def test_missing_methods(self):
+        fn = IndexedBasedFinder()
+
+        for method in ('pop', 'update', 'get', 'setdefault'):
+            with self.assertRaises(NotImplementedError, msg=method):
+                getattr(fn, method)()
+
+        with self.assertRaises(NotImplementedError):
+            fn['asd'] = 6


### PR DESCRIPTION
 - Make dict a base class of IndexBasedFinder (dirty workaround)
 - Do not rely on Expression('a + 3') == Expression('a + 3.'). See explanation here: https://github.com/sympy/sympy/issues/18054#issuecomment-566198899 