### PR TITLE
improve warning for plotting of non-integer number of samples

### DIFF
--- a/qupulse/pulses/plotting.py
+++ b/qupulse/pulses/plotting.py
@@ -167,8 +167,8 @@ def render(program: Union[AbstractInstructionBlock, Loop],
     if sample_count < 2:
         raise PlottingNotPossibleException(pulse=None,
                                            description='cannot render sequence with less than 2 data points')
-    if not float(sample_count).is_integer():
-        warnings.warn("Sample count is not an integer. Will be rounded (this changes the sample rate).")
+    if not round(float(sample_count), 10).is_integer():
+        warnings.warn(f"Sample count {sample_count} is not an integer. Will be rounded (this changes the sample rate).")
 
     times = np.linspace(float(start_time), float(end_time), num=int(sample_count), dtype=float)
     times[-1] = np.nextafter(times[-1], times[-2])


### PR DESCRIPTION
The plotting method issues a warning of the number of samples to be plotted is non-integer. This PR prevents issuing the warning in case of rounding errors.
