### PR TITLE
Keep TimeType precision if they are used in Expressions

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,6 +3,10 @@
     - Fix TimeType comparisons with non-finite floats (inf, -inf, NaN)
     - Drop python 3.5 support
 
+ - Expressions:
+    - Add `evaluate_with_exact_rationals` method to ExpressionScalar
+
+
 ## 0.5.1 ##
 
  - General:

--- a/qupulse/_program/waveforms.py
+++ b/qupulse/_program/waveforms.py
@@ -5,6 +5,7 @@ Classes:
 """
 
 import itertools
+from numbers import Real
 from abc import ABCMeta, abstractmethod
 from weakref import WeakValueDictionary, ref
 from typing import Union, Set, Sequence, NamedTuple, Tuple, Any, Iterable, FrozenSet, Optional, Mapping, AbstractSet
@@ -137,7 +138,7 @@ class Waveform(Comparable, metaclass=ABCMeta):
         return self
 
 
-class TableWaveformEntry(NamedTuple('TableWaveformEntry', [('t', float),
+class TableWaveformEntry(NamedTuple('TableWaveformEntry', [('t', Real),
                                                            ('v', float),
                                                            ('interp', InterpolationStrategy)])):
     def __init__(self, t: float, v: float, interp: InterpolationStrategy):

--- a/qupulse/_program/waveforms.py
+++ b/qupulse/_program/waveforms.py
@@ -222,7 +222,9 @@ class TableWaveform(Waveform):
             indices = slice(np.searchsorted(sample_times, entry1.t, 'left'),
                             np.searchsorted(sample_times, entry2.t, 'right'))
             output_array[indices] = \
-                entry2.interp((entry1.t, entry1.v), (entry2.t, entry2.v), sample_times[indices])
+                entry2.interp((float(entry1.t), entry1.v),
+                              (float(entry2.t), entry2.v),
+                              sample_times[indices])
         return output_array
 
     @property

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -14,7 +14,7 @@ import numpy
 
 from qupulse.serialization import AnonymousSerializable
 from qupulse.utils.sympy import sympify, to_numpy, recursive_substitution, evaluate_lambdified,\
-    get_most_simple_representation, get_variables, evaluate_lamdified_exact
+    get_most_simple_representation, get_variables, evaluate_lamdified_exact_rational
 from qupulse.utils.types import TimeType
 
 __all__ = ["Expression", "ExpressionVariableMissingException", "ExpressionScalar", "ExpressionVector", "ExpressionLike"]
@@ -250,6 +250,7 @@ class ExpressionScalar(Expression):
             self._sympified_expression = sympify(ex)
 
         self._variables = get_variables(self._sympified_expression)
+        self._exact_rational_lambdified = None
 
     @property
     def underlying_expression(self) -> sympy.Expr:
@@ -347,10 +348,13 @@ class ExpressionScalar(Expression):
     def is_nan(self) -> bool:
         return sympy.sympify('nan') == self._sympified_expression
 
-    def high_precision_eval_in_scope(self, scope: Mapping):
+    def evaluate_with_exact_rationals(self, scope: Mapping) -> Number:
         parsed_kwargs = self._parse_evaluate_numeric_arguments(scope)
-        result, _ = evaluate_lamdified_exact(self.sympified_expression, self.variables, parsed_kwargs, None)
-        return result
+        result, self._exact_rational_lambdified = evaluate_lamdified_exact_rational(self.sympified_expression,
+                                                                                    self.variables,
+                                                                                    parsed_kwargs,
+                                                                                    self._exact_rational_lambdified)
+        return self._parse_evaluate_numeric_result(result, scope)
 
 
 class ExpressionVariableMissingException(Exception):

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -14,7 +14,7 @@ import numpy
 
 from qupulse.serialization import AnonymousSerializable
 from qupulse.utils.sympy import sympify, to_numpy, recursive_substitution, evaluate_lambdified,\
-    get_most_simple_representation, get_variables
+    get_most_simple_representation, get_variables, evaluate_lamdified_exact
 from qupulse.utils.types import TimeType
 
 __all__ = ["Expression", "ExpressionVariableMissingException", "ExpressionScalar", "ExpressionVector", "ExpressionLike"]
@@ -346,6 +346,11 @@ class ExpressionScalar(Expression):
 
     def is_nan(self) -> bool:
         return sympy.sympify('nan') == self._sympified_expression
+
+    def high_precision_eval_in_scope(self, scope: Mapping):
+        parsed_kwargs = self._parse_evaluate_numeric_arguments(scope)
+        result, _ = evaluate_lamdified_exact(self.sympified_expression, self.variables, parsed_kwargs, None)
+        return result
 
 
 class ExpressionVariableMissingException(Exception):

--- a/qupulse/pulses/function_pulse_template.py
+++ b/qupulse/pulses/function_pulse_template.py
@@ -104,7 +104,7 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             parameters = {k: v for k, v in parameters.items() if k != 't'}
 
         expression = self.__expression.evaluate_symbolic(substitutions=parameters)
-        duration = self.__duration_expression.high_precision_eval_in_scope(parameters)
+        duration = self.__duration_expression.evaluate_with_exact_rationals(parameters)
 
         return FunctionWaveform(expression=expression,
                                 duration=duration,

--- a/qupulse/pulses/function_pulse_template.py
+++ b/qupulse/pulses/function_pulse_template.py
@@ -104,7 +104,7 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             parameters = {k: v for k, v in parameters.items() if k != 't'}
 
         expression = self.__expression.evaluate_symbolic(substitutions=parameters)
-        duration = self.__duration_expression.evaluate_numeric(**parameters)
+        duration = self.__duration_expression.high_precision_eval_in_scope(parameters)
 
         return FunctionWaveform(expression=expression,
                                 duration=duration,

--- a/qupulse/pulses/table_pulse_template.py
+++ b/qupulse/pulses/table_pulse_template.py
@@ -52,8 +52,8 @@ class TableEntry(NamedTuple('TableEntry', [('t', ExpressionScalar),
                                     interp)
 
     def instantiate(self, parameters: Dict[str, numbers.Real]) -> TableWaveformEntry:
-        return TableWaveformEntry(self.t.evaluate_numeric(**parameters),
-                                  self.v.evaluate_numeric(**parameters),
+        return TableWaveformEntry(self.t.high_precision_eval_in_scope(parameters),
+                                  self.v.evaluate_in_scope(parameters),
                                   self.interp)
 
     def get_serialization_data(self) -> tuple:

--- a/qupulse/pulses/table_pulse_template.py
+++ b/qupulse/pulses/table_pulse_template.py
@@ -52,7 +52,7 @@ class TableEntry(NamedTuple('TableEntry', [('t', ExpressionScalar),
                                     interp)
 
     def instantiate(self, parameters: Dict[str, numbers.Real]) -> TableWaveformEntry:
-        return TableWaveformEntry(self.t.high_precision_eval_in_scope(parameters),
+        return TableWaveformEntry(self.t.evaluate_with_exact_rationals(parameters),
                                   self.v.evaluate_in_scope(parameters),
                                   self.interp)
 

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -79,6 +79,8 @@ class TimeType:
             return cls.from_fraction(int(any), 1)
         if isinstance(any, numbers.Real):
             return cls.from_float(float(any))
+        if isinstance(any, numpy.ndarray):
+            return numpy.vectorize(cls._try_from_any)(any)
         return cls(any)
 
     @property

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -9,6 +9,7 @@ import collections
 import operator
 
 import numpy
+import sympy
 
 import qupulse.utils.numeric as qupulse_numeric
 
@@ -33,7 +34,7 @@ def _with_other_as_time_type(fn):
     """This is decorator to convert the other argument and the result into a :class:`TimeType`"""
     @functools.wraps(fn)
     def wrapper(self, other) -> 'TimeType':
-        converted = _converter.get(type(other), TimeType)(other)
+        converted = _converter.get(type(other), TimeType._try_from_any)(other)
         result = fn(self, converted)
         if result is NotImplemented:
             return result
@@ -58,7 +59,27 @@ class TimeType:
         if type(getattr(value, '_value', None)) is self._InternalType:
             self._value = value._value
         else:
-            self._value = self._to_internal(value)
+            try:
+                self._value = self._to_internal(value)
+            except TypeError as err:
+                raise TypeError(f'Could not create TimeType from {value} of type {type(value)}') from err
+
+    @classmethod
+    def _try_from_any(cls, any: typing.Any):
+        try:
+            cls(any)
+        except TypeError:
+            pass
+
+        if isinstance(any, numbers.Rational):
+            numerator = any.numerator() if callable(any.numerator) else any.numerator
+            denominator = any.denominator() if callable(any.denominator) else any.denominator
+            return cls.from_fraction(int(numerator), int(denominator))
+        if isinstance(any, numbers.Integral):
+            return cls.from_fraction(int(any), 1)
+        if isinstance(any, numbers.Real):
+            return cls.from_float(float(any))
+        return cls(any)
 
     @property
     def numerator(self):
@@ -251,6 +272,9 @@ numbers.Rational.register(TimeType)
 
 _converter = {
     float: TimeType.from_float,
+    TimeType._InternalType: TimeType,
+    fractions.Fraction: TimeType,
+    sympy.Rational: lambda q: TimeType.from_fraction(q.p, q.q),
     TimeType: lambda x: x
 }
 

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -68,6 +68,10 @@ class TimeType:
     def denominator(self):
         return self._value.denominator
 
+    def _sympy_(self):
+        import sympy
+        return sympy.Rational(self.numerator, self.denominator)
+
     def __round__(self, *args, **kwargs):
         return self._value.__round__(*args, **kwargs)
 

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -5,7 +5,7 @@ import numpy as np
 from sympy import sympify, Eq
 
 from qupulse.expressions import Expression, ExpressionVariableMissingException, NonNumericEvaluation, ExpressionScalar, ExpressionVector
-
+from qupulse.utils.types import TimeType
 
 class ExpressionTests(unittest.TestCase):
     def test_make(self):
@@ -380,6 +380,17 @@ class ExpressionScalarTests(unittest.TestCase):
         result = expr.evaluate_numeric(t=data)
 
         np.testing.assert_allclose(expected, result)
+
+    def test_evaluate_with_exact_rationals(self):
+        expr = ExpressionScalar('1 / 3')
+        self.assertEqual(TimeType.from_fraction(1, 3), expr.evaluate_with_exact_rationals({}))
+
+        expr = ExpressionScalar('a * (1 / 3)')
+        self.assertEqual(TimeType.from_fraction(2, 3), expr.evaluate_with_exact_rationals({'a': 2}))
+
+        expr = ExpressionScalar('dot(a, b) * (1 / 3)')
+        self.assertEqual(TimeType.from_fraction(10, 3),
+                         expr.evaluate_with_exact_rationals({'a': [2, 2], 'b': [1, 4]}))
 
 
 class ExpressionExceptionTests(unittest.TestCase):

--- a/tests/utils/time_type_tests.py
+++ b/tests/utils/time_type_tests.py
@@ -148,9 +148,37 @@ class TestTimeType(unittest.TestCase):
     def assert_try_from_any_works(self, time_type):
         try_from_any = time_type._try_from_any
 
+        # these duck types are here because isinstance(<gmpy2 obj>, numbers.<NumberType>) is version dependent
+        class DuckTypeWrapper:
+            def __init__(self, value):
+                self.value = value
+
+            def __repr__(self):
+                return f'{type(self)}({self.value})'
+
+        class DuckInt(DuckTypeWrapper):
+            def __int__(self):
+                return int(self.value)
+
+        class DuckFloat(DuckTypeWrapper):
+            def __float__(self):
+                return float(self.value)
+
+        class DuckIntFloat(DuckFloat):
+            def __int__(self):
+                return int(self.value)
+
+        class DuckRational:
+            def __init__(self, numerator, denominator):
+                self.numerator = numerator
+                self.denominator = denominator
+
+            def __repr__(self):
+                return f'{type(self)}({self.numerator}, {self.denominator})'
+
         for_array_tests = []
 
-        signed_int_types = [int, sympy.Integer, np.int8, np.int16, np.int32, np.int64]
+        signed_int_types = [int, sympy.Integer, np.int8, np.int16, np.int32, np.int64, DuckInt, DuckIntFloat]
         if gmpy2:
             signed_int_types.append(gmpy2.mpz)
 
@@ -169,7 +197,7 @@ class TestTimeType(unittest.TestCase):
                 self.assertEqual(expected_val, try_from_any(any_val))
                 for_array_tests.append((expected_val, any_val))
 
-        rational_types = [fractions.Fraction, sympy.Rational, time_type.from_fraction]
+        rational_types = [fractions.Fraction, sympy.Rational, time_type.from_fraction, DuckRational]
         if gmpy2:
             rational_types.append(gmpy2.mpq)
         for r_t in rational_types:
@@ -179,7 +207,7 @@ class TestTimeType(unittest.TestCase):
                 self.assertEqual(expected_val, try_from_any(any_val))
                 for_array_tests.append((expected_val, any_val))
 
-        float_types = [float, sympy.Float]
+        float_types = [float, sympy.Float, DuckFloat, DuckIntFloat]
         if gmpy2:
             float_types.append(gmpy2.mpfr)
         for f_t in float_types:

--- a/tests/utils/time_type_tests.py
+++ b/tests/utils/time_type_tests.py
@@ -13,6 +13,7 @@ except ImportError:
     gmpy2 = None
 
 import numpy as np
+import sympy
 
 import qupulse.utils.types as qutypes
 
@@ -143,6 +144,39 @@ class TestTimeType(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, '<= 1'):
             qutypes.time_from_float(.8, 2)
+
+    def assert_try_from_any_works(self, time_type):
+        try_from_any = time_type._try_from_any
+
+        signed_int_types = [int, sympy.Integer, np.int8, np.int16, np.int32, np.int64]
+        if gmpy2:
+            signed_int_types.append(gmpy2.mpz)
+
+        for s_t in signed_int_types:
+            self.assertEqual(1, try_from_any(s_t(1)))
+            self.assertEqual(17, try_from_any(s_t(17)))
+            self.assertEqual(-17, try_from_any(s_t(-17)))
+
+        unsigned_int_types = [np.uint8, np.uint16, np.uint32, np.uint]
+        for u_t in unsigned_int_types:
+            self.assertEqual(1, try_from_any(u_t(1)))
+            self.assertEqual(17, try_from_any(u_t(17)))
+
+        rational_types = [fractions.Fraction, sympy.Rational, time_type.from_fraction]
+        if gmpy2:
+            rational_types.append(gmpy2.mpq)
+        for r_t in rational_types:
+            self.assertEqual(fractions.Fraction(1, 3), try_from_any(r_t(1, 3)))
+
+        float_types = [float, sympy.Float]
+        if gmpy2:
+            float_types.append(gmpy2.mpfr)
+        for f_t in float_types:
+            self.assertEqual(time_type.from_float(3.4), try_from_any(f_t(3.4)))
+
+    def test_try_from_any(self):
+        self.assert_try_from_any_works(qutypes.TimeType)
+        self.assert_try_from_any_works(self.fallback_qutypes.TimeType)
 
     def assert_comparisons_work(self, time_type):
         tt = time_type.from_float(1.1)


### PR DESCRIPTION
Before this PR Rational objects in sympy expressions where evaluated as floats upon numeric evaluation. This PR adds `ScalarExpression.evaluate_with_exact_rationals` which is used for example in TablePT and FunctionPT to evaluate time expressions.

 - [x] Tests for TimeType._try_from_any