### PR TITLE
Fail tests on deprecation warnings

### DIFF
--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -207,6 +207,9 @@ class ExpressionVector(Expression):
     def __repr__(self):
         return 'ExpressionVector({})'.format(repr(self.get_serialization_data()))
 
+    def _sympy_(self):
+        return sympy.NDimArray(self._expression_vector)
+
     def __eq__(self, other):
         if not isinstance(other, Expression):
             other = Expression.make(other)
@@ -329,6 +332,9 @@ class ExpressionScalar(Expression):
 
     def __pos__(self):
         return self.make(self._sympified_expression.__pos__())
+
+    def _sympy_(self):
+        return self._sympified_expression
 
     @property
     def original_expression(self) -> Union[str, Number]:

--- a/qupulse/pulses/parameters.py
+++ b/qupulse/pulses/parameters.py
@@ -62,7 +62,8 @@ class ConstantParameter(Parameter):
         Args:
             value: The value of the parameter
         """
-        warnings.warn("ConstantParameter is deprecated. Use plain number types instead", DeprecationWarning)
+        warnings.warn("ConstantParameter is deprecated. Use plain number types instead", DeprecationWarning,
+                      stacklevel=2)
 
         super().__init__()
         try:
@@ -114,7 +115,8 @@ class MappedParameter(Parameter):
              dependencies (Dict(str -> Parameter)): Parameter objects of the dependencies. The objects them selves must
              not change but the parameters might return different values.
         """
-        warnings.warn("MappedParameter is deprecated. There should be no interface depending on it", DeprecationWarning)
+        warnings.warn("MappedParameter is deprecated. There should be no interface depending on it", DeprecationWarning,
+                      stacklevel=2)
 
         super().__init__()
         self._expression = expression

--- a/qupulse/serialization.py
+++ b/qupulse/serialization.py
@@ -113,7 +113,8 @@ class StorageBackend(metaclass=ABCMeta):
         Returns:
             List of all available identifiers.
         """
-        warnings.warn("list_contents is deprecated. Use the property contents instead", DeprecationWarning)
+        warnings.warn("list_contents is deprecated. Use the property contents instead", DeprecationWarning,
+                      stacklevel=2)
         return self.contents
 
     @property
@@ -308,7 +309,7 @@ class CachingBackend(StorageBackend):
                 IO functionality.
         """
         warnings.warn("CachingBackend is obsolete due to PulseStorage already offering caching functionality.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         self._backend = backend
         self._cache = {}
 
@@ -529,7 +530,8 @@ class Serializable(metaclass=SerializableMeta):
                 storing and later reconstruction as a Python object.
         """
         if serializer:
-            warnings.warn("{c}.get_serialization_data(*) was called with a serializer argument, indicating deprecated behavior. Please switch to the new serialization routines.".format(c=self.__class__.__name__), DeprecationWarning)
+            warnings.warn("{c}.get_serialization_data(*) was called with a serializer argument, indicating deprecated behavior. Please switch to the new serialization routines.".format(c=self.__class__.__name__),
+                          DeprecationWarning, stacklevel=2)
 
         if self.identifier:
             return {self.type_identifier_name: self.get_type_identifier(), self.identifier_name: self.identifier}
@@ -567,7 +569,8 @@ class Serializable(metaclass=SerializableMeta):
                 to this method.
          """
         if serializer:
-            warnings.warn("{c}.deserialize(*) was called with a serializer argument, indicating deprecated behavior. Please switch to the new serialization routines.".format(c=cls.__name__), DeprecationWarning)
+            warnings.warn("{c}.deserialize(*) was called with a serializer argument, indicating deprecated behavior. Please switch to the new serialization routines.".format(c=cls.__name__),
+                          DeprecationWarning, stacklevel=2)
 
         return cls(**kwargs)
 
@@ -632,7 +635,8 @@ class Serializer(object):
         self.__subpulses = dict() # type: Dict[str, Serializer.__FileEntry]
         self.__storage_backend = storage_backend
 
-        warnings.warn("Serializer is deprecated. Please switch to the new serialization routines.", DeprecationWarning)
+        warnings.warn("Serializer is deprecated. Please switch to the new serialization routines.",
+                      DeprecationWarning, stacklevel=2)
 
     def dictify(self, serializable: Serializable) -> Union[str, Dict[str, Any]]:
         """Converts a Serializable into a dictionary representation.
@@ -721,7 +725,8 @@ class Serializer(object):
         Args:
             serializable (Serializable): The Serializable to serialize and store
         """
-        warnings.warn("Serializer is deprecated. Please switch to the new serialization routines.", DeprecationWarning)
+        warnings.warn("Serializer is deprecated. Please switch to the new serialization routines.",
+                      DeprecationWarning, stacklevel=2)
         repr_ = self.__collect_dictionaries(serializable)
         for identifier in repr_:
             storage_identifier = identifier
@@ -742,7 +747,8 @@ class Serializer(object):
         See also:
             Serializable.deserialize
         """
-        warnings.warn("Serializer is deprecated. Please switch to the new serialization routines.", DeprecationWarning)
+        warnings.warn("Serializer is deprecated. Please switch to the new serialization routines.", DeprecationWarning,
+                      stacklevel=2)
         if isinstance(representation, str):
             if representation in self.__subpulses:
                 return self.__subpulses[representation].serializable

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,11 @@
 [tool:pytest]
 testpaths = tests tests/pulses tests/hardware tests/backward_compatibility
 python_files=*_tests.py *_bug.py
+filterwarnings =
+# action, message, category, module, lineno
+    error::DeprecationWarning
+# pytest uses readline which uses collections.abc
+    ignore:Using or importing the ABCs from \'collections\' instead of from \'collections\.abc\' is deprecated:DeprecationWarning:.*readline.*
 
 [build_sphinx]
 project = 'qupulse'

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,8 @@
 testpaths = tests tests/pulses tests/hardware tests/backward_compatibility
 python_files=*_tests.py *_bug.py
 filterwarnings =
-# action, message, category, module, lineno
+# syntax is action:message_regex:category:module_regex:lineno
+# we fail on all with a whitelist because a dependency might mess-up passing the correct stacklevel
     error::DeprecationWarning
 # pytest uses readline which uses collections.abc
     ignore:Using or importing the ABCs from \'collections\' instead of from \'collections\.abc\' is deprecated:DeprecationWarning:.*readline.*

--- a/tests/backward_compatibility/tabor_backward_compatibility_tests.py
+++ b/tests/backward_compatibility/tabor_backward_compatibility_tests.py
@@ -4,6 +4,7 @@ import json
 import typing
 import importlib.util
 import sys
+import warnings
 
 from tests.hardware.tabor_simulator_based_tests import TaborSimulatorManager
 from tests.hardware.dummy_devices import DummyDAC
@@ -158,7 +159,8 @@ class CompleteIntegrationTestHelper(unittest.TestCase):
         cls.test_state = PulseLoadingAndSequencingHelper(cls.data_folder, cls.pulse_name)
 
     def test_1_1_deserialization(self):
-        self.test_state.deserialize_pulse()
+        with self.assertWarns(DeprecationWarning):
+            self.test_state.deserialize_pulse()
 
     def test_1_2_deserialization_2018(self) -> None:
         self.test_state.deserialize_pulse_2018()

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -346,7 +346,7 @@ class ExpressionScalarTests(unittest.TestCase):
         self.assertIs(3 >= valued, True)
 
     def assertExpressionEqual(self, lhs: Expression, rhs: Expression):
-        self.assertTrue(bool(Eq(lhs.sympified_expression, rhs.sympified_expression)), '{} and {} are not equal'.format(lhs, rhs))
+        self.assertTrue(bool(Eq(lhs, rhs)), '{} and {} are not equal'.format(lhs, rhs))
 
     def test_number_math(self):
         a = ExpressionScalar('a')

--- a/tests/hardware/zihdawg_tests.py
+++ b/tests/hardware/zihdawg_tests.py
@@ -107,7 +107,7 @@ class HDAWGChannelPairTests(unittest.TestCase):
     def test_set_volatile_parameters(self):
         mock_device = mock.Mock()
 
-        parameters = {'a': ConstantParameter(9)}
+        parameters = {'a': 9}
         requested_changes = OrderedDict([(UserRegister.from_seqc(4), 2), (UserRegister.from_seqc(3), 6)])
 
         expected_user_reg_calls = [mock.call(*args) for args in requested_changes.items()]

--- a/tests/pulses/mapping_pulse_template_tests.py
+++ b/tests/pulses/mapping_pulse_template_tests.py
@@ -162,10 +162,10 @@ class MappingTemplateTests(unittest.TestCase):
         template = DummyPulseTemplate(parameter_names={'foo', 'bar'})
         st = MappingPulseTemplate(template, parameter_mapping={'foo': 't*k', 'bar': 't*l'})
 
-        parameters = {'t': ConstantParameter(3), 'k': ConstantParameter(2), 'l': ConstantParameter(7)}
+        parameters = {'t': 3, 'k': 2, 'l': 7}
         values = {'foo': 6, 'bar': 21}
         for k, v in st.map_parameters(parameters).items():
-            self.assertEqual(v.get_value(), values[k])
+            self.assertEqual(v, values[k])
         parameters.popitem()
         with self.assertRaises(ParameterNotProvidedException):
             st.map_parameters(parameters)
@@ -178,7 +178,9 @@ class MappingTemplateTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "type of return value"):
             st.map_parameters({})
 
-        parameters = dict(t=3, k=2, l=ConstantParameter(7))
+        with self.assertWarns(DeprecationWarning):
+            # remove if ConstantParameter is removed
+            parameters = dict(t=3, k=2, l=ConstantParameter(7))
         with self.assertRaisesRegex(TypeError, "neither all Parameter nor Real"):
             st.map_parameters(parameters)
 

--- a/tests/pulses/parameters_tests.py
+++ b/tests/pulses/parameters_tests.py
@@ -9,7 +9,8 @@ from tests.pulses.sequencing_dummies import DummyParameter
 
 class ConstantParameterTest(unittest.TestCase):
     def __test_valid_params(self, value: float) -> None:
-        constant_parameter = ConstantParameter(value)
+        with self.assertWarns(DeprecationWarning):
+            constant_parameter = ConstantParameter(value)
         self.assertEqual(value, constant_parameter.get_value())
         
     def test_float_values(self) -> None:
@@ -18,38 +19,44 @@ class ConstantParameterTest(unittest.TestCase):
         self.__test_valid_params(0.3)
 
     def test_requires_stop(self) -> None:
-        constant_parameter = ConstantParameter(0.3)
+        with self.assertWarns(DeprecationWarning):
+            constant_parameter = ConstantParameter(0.3)
         self.assertFalse(constant_parameter.requires_stop)
 
     def test_repr(self) -> None:
-        constant_parameter = ConstantParameter(0.2)
+        with self.assertWarns(DeprecationWarning):
+            constant_parameter = ConstantParameter(0.2)
         self.assertEqual("<ConstantParameter 0.2>", repr(constant_parameter))
 
     def test_expression_value(self) -> None:
         expression_str = "exp(4)*sin(pi/2)"
         expression_obj = Expression(expression_str)
         expression_val = expression_obj.evaluate_numeric()
-        param = ConstantParameter(expression_str)
-        self.assertEqual(expression_val, param.get_value())
-        param = ConstantParameter(expression_obj)
-        self.assertEqual(expression_val, param.get_value())
+        with self.assertWarns(DeprecationWarning):
+            param = ConstantParameter(expression_str)
+            self.assertEqual(expression_val, param.get_value())
+            param = ConstantParameter(expression_obj)
+            self.assertEqual(expression_val, param.get_value())
 
     def test_invalid_expression_value(self) -> None:
         expression_obj = Expression("sin(pi/2*t)")
         with self.assertRaises(RuntimeError):
-            ConstantParameter(expression_obj)
+            with self.assertWarns(DeprecationWarning):
+                ConstantParameter(expression_obj)
 
     def test_numpy_value(self) -> None:
         import numpy as np
         arr = np.array([6, 7, 8])
-        param = ConstantParameter(arr)
+        with self.assertWarns(DeprecationWarning):
+            param = ConstantParameter(arr)
         np.array_equal(arr, param.get_value())
 
 
 class MappedParameterTest(unittest.TestCase):
 
     def test_requires_stop_and_get_value(self) -> None:
-        p = MappedParameter(Expression("foo + bar * hugo"))
+        with self.assertWarns(DeprecationWarning):
+            p = MappedParameter(Expression("foo + bar * hugo"))
         with self.assertRaises(ParameterNotProvidedException):
             p.requires_stop
         with self.assertRaises(ParameterNotProvidedException):
@@ -75,13 +82,15 @@ class MappedParameterTest(unittest.TestCase):
         self.assertEqual(1.5, p.get_value())
 
     def test_repr(self) -> None:
-        p = MappedParameter(Expression("foo + bar * hugo"))
+        with self.assertWarns(DeprecationWarning):
+            p = MappedParameter(Expression("foo + bar * hugo"))
         self.assertIsInstance(repr(p), str)
 
     def test_equality(self):
-        p1 = MappedParameter(Expression("foo + 1"), {'foo': ConstantParameter(3)})
-        p2 = MappedParameter(Expression("foo + 1"), {'foo': ConstantParameter(4)})
-        p3 = MappedParameter(Expression("foo + 1"), {'foo': ConstantParameter(3)})
+        with self.assertWarns(DeprecationWarning):
+            p1 = MappedParameter(Expression("foo + 1"), {'foo': ConstantParameter(3)})
+            p2 = MappedParameter(Expression("foo + 1"), {'foo': ConstantParameter(4)})
+            p3 = MappedParameter(Expression("foo + 1"), {'foo': ConstantParameter(3)})
 
         self.assertEqual(p1, p3)
         self.assertNotEqual(p1, p2)

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -143,7 +143,7 @@ class PulseTemplateTest(unittest.TestCase):
 
     def test_create_program(self) -> None:
         template = PulseTemplateStub(defined_channels={'A'}, parameter_names={'foo'})
-        parameters = {'foo': ConstantParameter(2.126), 'bar': -26.2, 'hugo': 'exp(sin(pi/2))', 'append_a_child': '1'}
+        parameters = {'foo': 2.126, 'bar': -26.2, 'hugo': 'exp(sin(pi/2))', 'append_a_child': '1'}
         previous_parameters = parameters.copy()
         measurement_mapping = {'M': 'N'}
         previos_measurement_mapping = measurement_mapping.copy()
@@ -304,7 +304,10 @@ class PulseTemplateTest(unittest.TestCase):
 
     def test_create_program_none(self) -> None:
         template = PulseTemplateStub(defined_channels={'A'}, parameter_names={'foo'})
-        parameters = {'foo': ConstantParameter(2.126), 'bar': -26.2, 'hugo': 'exp(sin(pi/2))'}
+        with self.assertWarns(DeprecationWarning):
+            # just a test that old stuff wont break. remove in the future
+            constant_parameter = ConstantParameter(2.126)
+        parameters = {'foo': constant_parameter, 'bar': -26.2, 'hugo': 'exp(sin(pi/2))'}
         measurement_mapping = {'M': 'N'}
         channel_mapping = {'A': 'B'}
         volatile = {'hugo'}

--- a/tests/pulses/repetition_pulse_template_tests.py
+++ b/tests/pulses/repetition_pulse_template_tests.py
@@ -302,7 +302,6 @@ class RepetitionPulseTemplateSequencingTests(MeasurementWindowTestCase):
                                    global_transformation=None,
                                        parent_loop=program)
 
-        parameters = {'foo': ConstantParameter(7)}
         with self.assertRaises(ParameterNotProvidedException):
             t._internal_create_program(scope=scope,
                                        measurement_mapping=measurement_mapping,

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -6,7 +6,7 @@ from qupulse.expressions import Expression, ExpressionScalar
 from qupulse.pulses.table_pulse_template import TablePulseTemplate
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate, SequenceWaveform
 from qupulse.pulses.mapping_pulse_template import MappingPulseTemplate
-from qupulse.pulses.parameters import ConstantParameter, ParameterConstraint, ParameterConstraintViolation, ParameterNotProvidedException
+from qupulse.pulses.parameters import ParameterConstraint, ParameterConstraintViolation, ParameterNotProvidedException
 from qupulse._program._loop import Loop
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate,\
@@ -39,10 +39,10 @@ class SequencePulseTemplateTest(unittest.TestCase):
         self.outer_parameters = {'uptime', 'length', 'pulse_length', 'voltage'}
 
         self.parameters = dict()
-        self.parameters['uptime'] = ConstantParameter(5)
-        self.parameters['length'] = ConstantParameter(10)
-        self.parameters['pulse_length'] = ConstantParameter(100)
-        self.parameters['voltage'] = ConstantParameter(10)
+        self.parameters['uptime'] = 5
+        self.parameters['length'] = 10
+        self.parameters['pulse_length'] = 100
+        self.parameters['voltage'] = 10
 
         self.sequence = SequencePulseTemplate(MappingPulseTemplate(self.square,
                                                                    parameter_mapping=self.mapping1,

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -418,7 +418,8 @@ class FileSystemBackendTest(unittest.TestCase):
         for name in expected:
             self.backend.put(name, self.test_data)
 
-        self.assertEqual(expected, self.backend.list_contents(), msg="list_contents() faulty")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(expected, self.backend.list_contents(), msg="list_contents() faulty")
         self.assertEqual(expected, set(iter(self.backend)), msg="__iter__() faulty")
         self.assertEqual(3, len(self.backend), msg="__len__() faulty")
 
@@ -527,7 +528,8 @@ class ZipFileBackendTests(unittest.TestCase):
         for name in expected:
             self.backend.put(name, "asdfasdfas")
 
-        self.assertEqual(expected, self.backend.list_contents(), msg="list_contents() faulty")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(expected, self.backend.list_contents(), msg="list_contents() faulty")
         self.assertEqual(expected, set(iter(self.backend)), msg="__iter__() faulty")
         self.assertEqual(3, len(self.backend), msg="__len__() faulty")
 
@@ -629,7 +631,8 @@ class CachingBackendTests(unittest.TestCase):
         for name in expected:
             self.dummy_backend.put(name, "asdfasdfas")
 
-        self.assertEqual(expected, self.caching_backend.list_contents(), msg="list_contents() faulty")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(expected, self.caching_backend.list_contents(), msg="list_contents() faulty")
         self.assertEqual(expected, set(iter(self.caching_backend)), msg="__iter__() faulty")
         self.assertEqual(3, len(self.caching_backend), msg="__len__() faulty")
 
@@ -678,7 +681,8 @@ class DictBackendTests(unittest.TestCase):
         for name in expected:
             self.backend.put(name, "asdfasdfas")
 
-        self.assertEqual(expected, self.backend.list_contents(), msg="list_contents() faulty")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(expected, self.backend.list_contents(), msg="list_contents() faulty")
         self.assertEqual(expected, set(iter(self.backend)), msg="__iter__() faulty")
         self.assertEqual(3, len(self.backend), msg="__len__() faulty")
 


### PR DESCRIPTION
 - Configure pytest to fail on any `DeprecationWarning`
 - Fix warning by sympy by adding explicit `Expression._sympy_`
 - Ignore a warning that is emitted by a pytest dependency