### PR TITLE
performance improvement for sampling

### DIFF
--- a/qupulse/hardware/util.py
+++ b/qupulse/hardware/util.py
@@ -95,7 +95,6 @@ def get_sample_times(waveforms: Union[Collection[Waveform], Waveform],
         segment_lengths.append(rounded_segment_length)
 
     segment_lengths = np.asarray(segment_lengths, dtype=np.uint64)
-    float_sample_rate = float(sample_rate_in_GHz)
-    time_array = np.arange(0, np.max(segment_lengths)/float_sample_rate, float_sample_rate) 
+    time_array = np.arange(np.max(segment_lengths), dtype=float) / float(sample_rate_in_GHz)
 
     return time_array, segment_lengths

--- a/qupulse/hardware/util.py
+++ b/qupulse/hardware/util.py
@@ -95,6 +95,7 @@ def get_sample_times(waveforms: Union[Collection[Waveform], Waveform],
         segment_lengths.append(rounded_segment_length)
 
     segment_lengths = np.asarray(segment_lengths, dtype=np.uint64)
-    time_array = np.arange(np.max(segment_lengths)) / float(sample_rate_in_GHz)
+    float_sample_rate = float(sample_rate_in_GHz)
+    time_array = np.arange(0, np.max(segment_lengths)/float_sample_rate, float_sample_rate) 
 
     return time_array, segment_lengths


### PR DESCRIPTION
This PR improves sampling speed of the `get_sample_times` method.

```
%timeit np.arange(10000)/2.4
21 µs ± 132 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit np.arange(0, 10000/2.4, 1/2.4)
6.81 µs ± 28.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

a=np.arange(10000)/2.4

b=np.arange(0, 10000/2.4, 1/2.4)

a-b
Out[184]: array([0., 0., 0., ..., 0., 0., 0.])

np.max(np.abs(a-b))
Out[185]: 0.0
```

@terrorfisch 