### PR TITLE
add python 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 3.6
   - 3.7
+  - 3.8
 env:
   - INSTALL_EXTRAS=[VISA,plotting,zurich-instruments,tektronix]
   - INSTALL_EXTRAS=[VISA,plotting,zurich-instruments,tektronix,Faster-fractions]


### PR DESCRIPTION
Add python 3.8 to CI. We have used qupulse locally with python 3.8 for some time now.