### PR TITLE
Remove typing.Collection backport and improve python 3.8 support

### DIFF
--- a/qupulse/hardware/awgs/tektronix.py
+++ b/qupulse/hardware/awgs/tektronix.py
@@ -609,7 +609,7 @@ class TektronixAWG(AWG):
         if previous_errors:
             self.logger.warning("Error queue not empty before sequence upload: %r", previous_errors)
 
-        positions_with_next = pairwise(positions, fillvalue=last_jump_to)
+        positions_with_next = pairwise(positions, zip_function=itertools.zip_longest, fillvalue=last_jump_to)
 
         self._synchronized = False
         for idx, ((element_index, next_element), sequencing_element) in enumerate(zip(positions_with_next, sequencing_elements)):

--- a/qupulse/hardware/feature_awg/base.py
+++ b/qupulse/hardware/feature_awg/base.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Collection
 import weakref
 
 from qupulse.hardware.awgs.base import AWG
 from qupulse.hardware.feature_awg.base_features import Feature, FeatureAble
-from qupulse.utils.types import Collection
 
 __all__ = ["AWGDevice", "AWGChannelTuple", "AWGChannel", "AWGMarkerChannel", "AWGDeviceFeature", "AWGChannelFeature",
            "AWGChannelTupleFeature"]

--- a/qupulse/hardware/feature_awg/tabor.py
+++ b/qupulse/hardware/feature_awg/tabor.py
@@ -3,7 +3,8 @@ import logging
 import numbers
 import sys
 import weakref
-from typing import List, Tuple, Set, Callable, Optional, Any, cast, Union, Dict, Mapping, NamedTuple, Iterable
+from typing import List, Tuple, Set, Callable, Optional, Any, cast, Union, Dict, Mapping, NamedTuple, Iterable,\
+    Collection
 from collections import OrderedDict
 import numpy as np
 from qupulse import ChannelID
@@ -15,7 +16,7 @@ from qupulse.hardware.feature_awg.features import ChannelSynchronization, Amplit
     ReadProgram, RepetitionMode
 from qupulse.hardware.util import voltage_to_uint16, find_positions
 
-from qupulse.utils.types import Collection, TimeType
+from qupulse.utils.types import TimeType
 from qupulse.hardware.feature_awg.base import AWGChannelTuple, AWGChannel, AWGDevice, AWGMarkerChannel
 from typing import Sequence
 from qupulse._program.tabor import TaborSegment, TaborException, TaborProgram, PlottableProgram, TaborSequencing, \

--- a/qupulse/hardware/util.py
+++ b/qupulse/hardware/util.py
@@ -1,10 +1,10 @@
-from typing import List, Sequence, Tuple, Union
+from typing import List, Sequence, Tuple, Union, Collection
 import itertools
 
 import numpy as np
 
 from qupulse._program.waveforms import Waveform
-from qupulse.utils.types import TimeType, Collection
+from qupulse.utils.types import TimeType
 from qupulse.utils import pairwise
 
 __all__ = ['voltage_to_uint16', 'get_sample_times']

--- a/qupulse/pulses/table_pulse_template.py
+++ b/qupulse/pulses/table_pulse_template.py
@@ -15,8 +15,8 @@ import warnings
 import numpy as np
 import sympy
 from sympy.logic.boolalg import BooleanAtom
-import more_itertools
 
+from qupulse.utils import pairwise
 from qupulse.utils.types import ChannelID
 from qupulse.serialization import Serializer, PulseRegistryType
 from qupulse.pulses.parameters import Parameter, \
@@ -75,7 +75,7 @@ class TableEntry(NamedTuple('TableEntry', [('t', ExpressionScalar),
             Scalar expression for the integral.
         """
         expr = 0
-        for first_entry, second_entry in more_itertools.pairwise(entry_sequence):
+        for first_entry, second_entry in pairwise(entry_sequence):
             substitutions = {'t0': first_entry.t.sympified_expression,
                              'v0': expression_extractor(first_entry.v),
                              't1': second_entry.t.sympified_expression,
@@ -113,7 +113,7 @@ class TableEntry(NamedTuple('TableEntry', [('t', ExpressionScalar),
         if post_value is not None:
             piecewise_args.append((post_value, t >= entry_sequence[-1].t.sympified_expression))
 
-        for first_entry, second_entry in more_itertools.pairwise(entry_sequence):
+        for first_entry, second_entry in pairwise(entry_sequence):
             t0, t1 = first_entry.t.sympified_expression, second_entry.t.sympified_expression
             substitutions = {'t0': t0,
                              'v0': expression_extractor(first_entry.v),

--- a/qupulse/utils/__init__.py
+++ b/qupulse/utils/__init__.py
@@ -1,6 +1,6 @@
 """This package contains utility functions and classes as well as custom sympy extensions(hacks)."""
 
-from typing import Union, Iterable, Any, Tuple, Mapping
+from typing import Union, Iterable, Any, Tuple, Mapping, Iterator, cast
 import itertools
 import re
 import numbers
@@ -44,12 +44,12 @@ if not isclose:
 
 
 def pairwise(iterable: Iterable[Any],
-             zip_function=itertools.zip_longest, **kwargs) -> Iterable[Tuple[Any, Any]]:
+             zip_function=zip, **kwargs) -> Iterator[Tuple[Any, Any]]:
     """s -> (s0,s1), (s1,s2), (s2, s3), ...
 
     Args:
         iterable: Iterable to iterate over pairwise
-        zip_function: Either zip or itertools.zip_longest(default)
+        zip_function: Either zip(default) or itertools.zip_longest
         **kwargs: Gets passed to zip_function
 
     Returns:
@@ -57,7 +57,7 @@ def pairwise(iterable: Iterable[Any],
     """
     a, b = itertools.tee(iterable)
     next(b, None)
-    return zip_function(a, b, **kwargs)
+    return cast(Iterator[Tuple[Any, Any]], zip_function(a, b, **kwargs))
 
 
 def grouper(iterable: Iterable[Any], n: int, fillvalue=None) -> Iterable[Tuple[Any, ...]]:

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -377,38 +377,6 @@ def has_type_interface(obj: typing.Any, type_obj: typing.Type) -> bool:
     return set(dir(obj)) >= {attr for attr in dir(type_obj) if not attr.startswith('_')}
 
 
-if hasattr(typing, 'Collection'):
-    Collection = typing.Collection
-else:
-    def _check_methods(C, *methods):
-        """copied from https://github.com/python/cpython/blob/3.8/Lib/_collections_abc.py"""
-        mro = C.__mro__
-        for method in methods:
-            for B in mro:
-                if method in B.__dict__:
-                    if B.__dict__[method] is None:
-                        return NotImplemented
-                    break
-            else:
-                return NotImplemented
-        return True
-
-    class _ABCCollection(collections.abc.Sized, collections.abc.Iterable, collections.abc.Container):
-        """copied from https://github.com/python/cpython/blob/3.8/Lib/_collections_abc.py"""
-        __slots__ = ()
-
-        @classmethod
-        def __subclasshook__(cls, C):
-            # removed "if cls is _ABCCollection" guard because reloading this module damages the test
-            return _check_methods(C, "__len__", "__iter__", "__contains__")
-
-    class Collection(typing.Sized, typing.Iterable[typing.T_co], typing.Container[typing.T_co],
-                     extra=_ABCCollection):
-        """Fallback for typing.Collection if python 3.5
-        copied from https://github.com/python/cpython/blob/3.5/Lib/typing.py"""
-        __slots__ = ()
-
-
 _KT_hash = typing.TypeVar('_KT_hash', bound=typing.Hashable)  # Key type.
 _T_co_hash = typing.TypeVar('_T_co_hash', bound=typing.Hashable, covariant=True)  # Any type covariant containers.
 

--- a/tests/_program/seqc_tests.py
+++ b/tests/_program/seqc_tests.py
@@ -5,6 +5,7 @@ from itertools import zip_longest, islice
 import sys
 import tempfile
 import pathlib
+import hashlib
 
 import numpy as np
 
@@ -51,7 +52,8 @@ def get_unique_wfs(n=10000, duration=32, defined_channels=frozenset(['A'])):
     key = (n, duration)
 
     if key not in get_unique_wfs.cache:
-        h = hash(key)
+        # positive deterministic int64
+        h = int(hashlib.sha256(str(key).encode('ascii')).hexdigest()[:2*8], base=16) // 2
         base = np.bitwise_xor(np.linspace(-h, h, num=duration + n, dtype=np.int64), h)
         base = base / np.max(np.abs(base))
 
@@ -768,7 +770,7 @@ const PLAYBACK_FINISHED_MASK = 0b1000000000000000000000000000000;
 const PROG_SEL_MASK = 0b111111111111111111111111111111;
 const INVERTED_PROG_SEL_MASK = 0b11000000000000000000000000000000;
 const IDLE_WAIT_CYCLES = 300;
-wave test_concatenated_waveform_0 = "3e0090e8ffd002d1134ce38827c6a35fede89cf23d126a44057ef43f466ae4cd";
+wave test_concatenated_waveform_0 = "c583e709957ec1536986ae1c7a6ad6311c89e052405d2a5c786760fc2fcdf6e3";
 wave test_shared_waveform_121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518 = "121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518";
 
 // function used by manually triggered programs

--- a/tests/hardware/feature_awg/awg_new_driver_base_tests.py
+++ b/tests/hardware/feature_awg/awg_new_driver_base_tests.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, Optional, Set, Tuple
+from typing import Callable, Iterable, Optional, Set, Tuple, Collection
 import unittest
 import warnings
 
@@ -8,7 +8,6 @@ from qupulse.hardware.feature_awg import channel_tuple_wrapper
 from qupulse.hardware.feature_awg.base import AWGDevice, AWGChannel, AWGChannelTuple, AWGMarkerChannel
 from qupulse.hardware.feature_awg.features import ChannelSynchronization, ProgramManagement, VoltageRange, \
     AmplitudeOffsetHandling, RepetitionMode, VolatileParameters
-from qupulse.utils.types import Collection
 
 
 ########################################################################################################################

--- a/tests/utils/types_tests.py
+++ b/tests/utils/types_tests.py
@@ -3,7 +3,7 @@ import inspect
 
 import numpy as np
 
-from qupulse.utils.types import (HashableNumpyArray, Collection, SequenceProxy, _FrozenDictByWrapping,
+from qupulse.utils.types import (HashableNumpyArray, SequenceProxy, _FrozenDictByWrapping,
                                  _FrozenDictByInheritance)
 
 
@@ -18,15 +18,6 @@ class HashableNumpyArrayTest(unittest.TestCase):
 
         self.assertNotEqual(hash(a), hash(b))
         self.assertEqual(hash(a), hash(c))
-
-
-class CollectionTests(unittest.TestCase):
-    def test_isinstance(self):
-        self.assertTrue(isinstance(set(), Collection))
-        self.assertTrue(isinstance(list(), Collection))
-        self.assertTrue(isinstance(tuple(), Collection))
-
-        self.assertFalse(isinstance(5, Collection))
 
 
 class SequenceProxyTest(unittest.TestCase):


### PR DESCRIPTION
A custom `Collection` is no longer required because python 3.5 support was dropped.

A few tests relied on bad hashing behaviour of tuples which was fixed in python 3.8
https://bugs.python.org/issue34751

This PR fixes those tests.

Remove an overlooked more_itertools function call on which we no longer depend
https://github.com/qutech/qupulse/commit/651335619f40e2c6b443171515d8fc6bb82da417