### PR TITLE
Feature variable error margins

### DIFF
--- a/qupulse/_program/waveforms.py
+++ b/qupulse/_program/waveforms.py
@@ -25,6 +25,7 @@ from qupulse._program.transformation import Transformation
 __all__ = ["Waveform", "TableWaveform", "TableWaveformEntry", "FunctionWaveform", "SequenceWaveform",
            "MultiChannelWaveform", "RepetitionWaveform", "TransformingWaveform", "ArithmeticWaveform"]
 
+PULSE_TO_WAVEFORM_ERROR = None # error margin in pulse template to waveform conversion
 
 class Waveform(Comparable, metaclass=ABCMeta):
     """Represents an instantiated PulseTemplate which can be sampled to retrieve arrays of voltage
@@ -213,7 +214,7 @@ class TableWaveform(Waveform):
 
     @property
     def duration(self) -> TimeType:
-        return TimeType.from_float(self._table[-1].t)
+        return TimeType.from_float(self._table[-1].t, absolute_error = PULSE_TO_WAVEFORM_ERROR)
 
     def unsafe_sample(self,
                       channel: ChannelID,
@@ -262,7 +263,7 @@ class FunctionWaveform(Waveform):
             raise ValueError('FunctionWaveforms may not depend on anything but "t"')
 
         self._expression = expression
-        self._duration = TimeType.from_float(duration)
+        self._duration = TimeType.from_float(duration, absolute_error = PULSE_TO_WAVEFORM_ERROR)
         self._channel_id = channel
 
     @property

--- a/qupulse/utils/sympy.py
+++ b/qupulse/utils/sympy.py
@@ -28,6 +28,7 @@ __all__ = ["sympify", "substitute_with_eval", "to_numpy", "get_variables", "get_
 
 Sympifyable = Union[str, Number, sympy.Expr, numpy.str_]
 
+SYMPY_DURATION_ERROR_MARGIN = 1e-15 # error margin when checking sympy expression durations
 
 class IndexedBasedFinder(dict):
     """Acts as a symbol lookup and determines which symbols in an expression a subscripted."""
@@ -375,7 +376,7 @@ def evaluate_lamdified_exact_rational(expression: sympy.Expr,
     return lambdified(**parameters), lambdified
 
 
-def almost_equal(lhs: sympy.Expr, rhs: sympy.Expr, epsilon: float=1e-15) -> Optional[bool]:
+def almost_equal(lhs: sympy.Expr, rhs: sympy.Expr, epsilon: float=SYMPY_DURATION_ERROR_MARGIN) -> Optional[bool]:
     """Returns True (or False) if the two expressions are almost equal (or not). Returns None if this cannot be
     determined."""
     relation = sympy.simplify(sympy.Abs(lhs - rhs) <= epsilon)

--- a/qupulse/utils/sympy.py
+++ b/qupulse/utils/sympy.py
@@ -376,9 +376,11 @@ def evaluate_lamdified_exact_rational(expression: sympy.Expr,
     return lambdified(**parameters), lambdified
 
 
-def almost_equal(lhs: sympy.Expr, rhs: sympy.Expr, epsilon: float=SYMPY_DURATION_ERROR_MARGIN) -> Optional[bool]:
+def almost_equal(lhs: sympy.Expr, rhs: sympy.Expr, epsilon: Optional[float]=None) -> Optional[bool]:
     """Returns True (or False) if the two expressions are almost equal (or not). Returns None if this cannot be
     determined."""
+    if epsilon is None:
+        epsilon = SYMPY_DURATION_ERROR_MARGIN
     relation = sympy.simplify(sympy.Abs(lhs - rhs) <= epsilon)
 
     if relation is sympy.true:


### PR DESCRIPTION
For our waveforms we need different values for some of the error margins. This PR makes them configurable.

```
In [1]: import qupulse.utils.sympy
   ...: from qupulse.utils.sympy import almost_equal
   ...: print(qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN)
   ...: print(almost_equal(0, 1e-14))
   ...: 
   ...: qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN=1e-6
   ...: 
   ...: print(qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN)
   ...: print(almost_equal(0, 1e-14))
1e-15
False
1e-06
True
```
@terrorfisch 
