### PR TITLE
Add ConstantPulseTemplate

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,7 +2,8 @@
  - General:
     - Fix TimeType comparisons with non-finite floats (inf, -inf, NaN)
     - Drop python 3.5 support
-
+    - Added ConstantPulseTemplate (#565)
+    
  - Expressions:
     - Add `evaluate_with_exact_rationals` method to ExpressionScalar
 

--- a/doc/source/examples/03ConstantPulseTemplate.ipynb
+++ b/doc/source/examples/03ConstantPulseTemplate.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The ConstantPulseTemplate\n",
+    "\n",
+    "The `ConstantPulseTemplate`(or short `ConstantPT`) can be used to define pulse templates with all channels a constant value. The template is easy to define and allows backends to optimize the waveforms on an AWG."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'A', 'B'}\n",
+      "{'A': Expression('10.0000000000000'), 'B': Expression('2.00000000000000')}\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "from qupulse.pulses import ConstantPT\n",
+    "\n",
+    "constant_template = ConstantPT(10, {'A': 1., 'B': .2})\n",
+    "\n",
+    "print(constant_template.defined_channels)\n",
+    "print(constant_template.integral)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The pulse template has two channels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\projects\\qupulse\\qupulse\\pulses\\plotting.py:236: UserWarning: Matplotlib is currently using module://ipykernel.pylab.backend_inline, which is a non-GUI backend, so cannot show the figure.\n",
+      "  axes.get_figure().show()\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAX5UlEQVR4nO3de3SV9Z3v8feHAI22iheirUSayIFREAwYKCPjZbyircFa68GlrfVYmfbUnl48Hah2eWmdtna6utrpcjzFy1FOMVStVdqitlZa6nRUQBEERNDGGkDF2EFREdDv+WNv6DYkYSfsZ2+S3+e1Vlb283tu3ydiPnluv58iAjMzS1e/ShdgZmaV5SAwM0ucg8DMLHEOAjOzxDkIzMwS17/SBXTX4MGDo66urtJlmJn1KosXL34lImo6mtfrgqCuro5FixZVugwzs15F0vOdzfOlITOzxDkIzMwS5yAwM0ucg8DMLHEOAjOzxDkIzMwS5yAwM0ucg8DMLHEOAjOzxDkIzMwS5yAwM0ucg8DMLHEOAjOzxGUWBJJukfSypKc6mS9J/yZpjaSlksZlVYuZmXUuyzOCW4HJXcw/HRie/5oG3JBhLWZm1onMxiOIiAWS6rpYZAowKyICeETSfpI+FBHrs6jnhVffpKXtjSw2bWZWFsNqPsAh++1V8u1WcmCaIcALBdOt+badgkDSNHJnDQwdOrRHO5u3bD3fue/pHq1rZrYnuPasI7lg4odLvt1eMUJZRMwEZgI0NjZGT7YxpWEIR394/5LWZWZWTkMP3DuT7VYyCNYChxZM1+bbMvHBQdV8cFB1Vps3M+u1Kvn46Fzg0/mnhyYCG7O6P2BmZp3L7IxAUjNwAjBYUitwFTAAICL+DzAPOANYA7wJXJRVLWZm1rksnxo6bxfzA/hCVvs3M7Pi+M1iM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEZRoEkiZLWiVpjaQZHcwfKmm+pCckLZV0Rpb1mJnZzjILAklVwPXA6cBI4DxJI9st9g3gjogYC0wF/j2reszMrGNZnhFMANZExHMRsQWYA0xpt0wA++Y/DwLWZViPmZl1IMsgGAK8UDDdmm8rdDVwgaRWYB7wxY42JGmapEWSFm3YsCGLWs3MklXpm8XnAbdGRC1wBvD/JO1UU0TMjIjGiGisqakpe5FmZn1ZlkGwFji0YLo231boYuAOgIj4T6AaGJxhTWZm1k6WQbAQGC6pXtJAcjeD57Zb5i/ASQCSjiAXBL72Y2ZWRpkFQURsAy4FHgBWkns6aLmkb0pqyi92GXCJpCeBZuAzERFZ1WRmZjvrn+XGI2IeuZvAhW1XFnxeAUzKsgYzM+tapW8Wm5lZhTkIzMwS5yAwM0ucg8DMLHEOAjOzxDkIzMwS5yAwM0ucg8DMLHG7fKFMUiNwLHAI8BbwFPDbiPhrxrWZmVkZdHpGIOkiSY8DXwf2AlYBLwP/ADwo6TZJQ8tTppmZZaWrM4K9gUkR8VZHMyU1AMPJdRxnZma9VKdBEBHXd7ViRCwpeTVmZlZ2PbpZLOljpS7EzMwqo6dPDY0vaRVmZlYxPQqCiLiq1IWYmVllFPP46Kc7ao+IWaUvx8zMyq2YgWkKLwNVkxta8nHAQWBm1gfsMggi4ouF05L2A+ZkVZCZmZVXT+4RvAHUl7oQMzOrjGLuEfwS2D6gfD9gJHBHlkWZmVn5FHOP4PsFn7cBz0dEa0b1mJlZmRVzj+AP5SjEzMwqo6dvFs8sdSFmZlYZxVwa6shPSlqFmSVp69attLa2snnz5kqX0mdUV1dTW1vLgAEDil6nR0EQEYt7sp6ZWaHW1lb22Wcf6urqkFTpcnq9iKCtrY3W1lbq64t/uLOYp4ZqgOnknhaqLtjhiT0p1Mxsu82bNzsESkgSBx54IBs2bOjWesXcI5gNrCT37sA1QAuwsLsFmpl1xCFQWj35eRYTBAdGxM3A1oj4Q0T8D8BnA2bWZ33mM5/hrrvuqsi+W1paOPLIIzud/8Mf/pDq6mo2btxYsn0WEwRb89/XS/qopLHAASWrwMzMitbc3Mz48eO5++67S7bNYoLgWkmDgMuA/w3cBHylZBWYmVXQrFmzGDNmDEcddRSf+tSndrQvWLCAY445hsMOO2zH2cGmTZs46aSTGDduHKNHj+bee+8Fcn/FH3HEEVxyySWMGjWKU089lbfeyo3ye8IJJzB9+nQmTJjAiBEj+OMf/wjAO++8w9e+9jXGjx/PmDFj+MlPdv0w5rPPPsumTZu49tpraW5uLtnPoJgXyn6V/7gR+MeS7dnMrMA1v1zOinWvlXSbIw/Zl6vOHNXp/OXLl3Pttdfypz/9icGDB/Pqq6/umLd+/Xoefvhhnn76aZqamjjnnHOorq7mF7/4Bfvuuy+vvPIKEydOpKmpCYDVq1fT3NzMjTfeyLnnnsvPf/5zLrjgAgC2bdvGY489xrx587jmmmt48MEHufnmmxk0aBALFy7k7bffZtKkSZx66qldXuOfM2cOU6dO5dhjj2XVqlW89NJLHHzwwbv9c+r0jEDSNyR1eglI0okestLMerOHHnqIT37ykwwePBiAAw7426+8s846i379+jFy5EheeuklIPd45uWXX86YMWM4+eSTWbt27Y559fX1NDQ0AHD00UfT0tKyY1tnn332Tu2/+c1vmDVrFg0NDXzkIx+hra2N1atXd1lvc3MzU6dOpV+/fnziE5/gzjvvLMWPocszgmXALyVtJjf+wAZyj48OBxqAB4Fvl6QKM0teV3+5V8L73ve+HZ8jcv1uzp49mw0bNrB48WIGDBhAXV3djpfhCpevqqracWmocF5VVRXbtm3bsc0f//jHnHbaae/Zb2GAFFq2bBmrV6/mlFNOAWDLli3U19dz6aWX7uaRdnFGEBH3RsQk4HPAcqAKeA34KTAhIr4SEd17WNXMbA9y4okncuedd9LW1gbwnktDHdm4cSMHHXQQAwYMYP78+Tz//PM93vdpp53GDTfcwNatuedxnnnmGd54441Ol29ububqq6+mpaWFlpYW1q1bx7p163arhu2KuUewGuj6fMXMrBcaNWoUV1xxBccffzxVVVWMHTuWW2+9tdPlzz//fM4880xGjx5NY2Mjhx9+eI/3/dnPfpaWlhbGjRtHRFBTU8M999zT6fJz5sxh3rx572n7+Mc/zpw5c5g+fXqP6wDQ9lOe3qKxsTEWLVpU6TLMrARWrlzJEUccUeky+pyOfq6SFkdEY0fL96j30WJJmixplaQ1kmZ0ssy5klZIWi7p9izrMTOznfW099FdklQFXA+cArQCCyXNjYgVBcsMB74OTIqIv0o6KKt6zMysY7s8I5A0QtLvJD2Vnx4j6RtFbHsCsCYinouILeQGvJ/SbplLgOsj4q8AEfFy98o3M7PdVcyloRvJ/dW+FSAilgJTi1hvCPBCwXRrvq3QCGCEpP+Q9IikyR1tSNI0SYskLepur3pmZta1YoJg74h4rF3bthLtvz+59xJOAM4DbpS0X/uFImJmRDRGRGNNTU2Jdm1mZlBcELwiaRgQAJLOAdYXsd5a4NCC6dp8W6FWYG5EbI2IPwPPkAsGMzMrk2KC4AvkhqY8XNJa4MvA54tYbyEwXFK9pIHkLifNbbfMPeTOBpA0mNyloueKKdzMLCt7YjfULS0t7LXXXjQ0NHDUUUdxzDHHsGrVqpLsc5dBkL/ZezJQAxweEf8QES1FrLcNuBR4gNzANndExHJJ35TUlF/sAaBN0gpgPvC1iGjr4bGYmfVpw4YNY8mSJTz55JNceOGFfPvbpenlp5inhr4q6avAPwGX5KcvltSwq3UjYl5EjIiIYRHxL/m2KyNibv5zRMRXI2JkRIyOiDm7eTxmZt3Sm7qhLvTaa6+x//77l+JHUNR7BI35r1/mpz8GLAU+J+nOiPheSSoxs7TdNwNeXFbabX5wNJz+3U5n97ZuqJ999lkaGhp4/fXXefPNN3n00UdL8mMqJghqgXERsQlA0lXAr4HjgMWAg8DMeqWedkO9YMEC+vXrt9vdUC9dunTH2cbGjRtZvXo1I0aM6LTe7ZeGAH72s58xbdo07r///t3+ORQTBAcBbxdMbwUOjoi3JL3dyTpmZt3TxV/ulbCndUPdXlNTExdddFH3D6wDxTw1NBt4VNJV+bOB/wBul/R+YEXXq5qZ7bl6UzfU7T388MMMGzasx/svVEw31N+SdD9wTL7pcxGxvfvP80tShZlZBfSmbqjhb/cIIoKBAwdy00039Xj/hYruhjrfIVz19umI+EtJKugmd0Nt1ne4G+pslLwbaklNklYDfwb+kP9+XwlqNTOzPUAx9wi+BUwEnomIeuBk4JFMqzIzs7IpJgi25t/27SepX0TMJ/degZmZ9QHFPD76X5I+ACwAZkt6GSj+1raZWRciosuXqKx7ejL8cDFnBFOAN4GvAPcDz5J7u9jMbLdUV1fT1tbWo19etrOIoK2tjerq6l0vXKCYM4IrI2I68C5wG4Ck64Dp3a7SzKxAbW0tra2teMCp0qmurqa2trZb6xQTBKew8y/90ztoMzPrlgEDBlBfX1/pMpLXaRBI+jzwP4HDJC0tmLUPubeLzcysD+jqjOB2cu8LfAeYUdD+ekR0/R62mZn1Gl0FQRXwGrkRyt5D0gEOAzOzvqGrIFhMfpxioP2zXQEclklFZmZWVp0GQf4tYjMz6+OKeWqI/BjDx+Unfx8Rv8quJDMzK6diOp37LvAlcmMPrAC+JKk0IyabmVnFFXNGcAbQEBHvAki6DXgCuDzLwszMrDyK6WICYL+Cz4MyqMPMzCqkmDOC7wBPSJpP7umh43jvewVmZtaLdfVm8fXA7RHRLOn3wPj8rOkR8WI5ijMzs+x1dUbwDPB9SR8C7gCaI+KJ8pRlZmbl0uk9goj4UUT8PXA80AbcIulpSVdJGlG2Cs3MLFO7vFkcEc9HxHURMRY4DzgLWJl1YWZmVh7FvEfQX9KZkmaT64RuFXB25pWZmVlZdHWz+BRyZwBnAI8Bc4BpEeFhKs3M+pCubhZ/nVxX1JdFxF/LVI+ZmZVZV53OnVjOQszMrDKKfbPYzMz6KAeBmVniHARmZolzEJiZJc5BYGaWuEyDQNJkSaskrZHUaY+lkj4hKSQ1ZlmPmZntLLMgkFQFXA+cDowEzpM0soPl9iE3AtqjWdViZmady/KMYAKwJiKei4gt5N5MntLBct8CrgM2Z1iLmZl1IssgGAK8UDDdmm/bQdI44NCI+HVXG5I0TdIiSYs2bNhQ+krNzBJWsZvFkvoBPwAu29WyETEzIhojorGmpib74szMEpJlEKwFDi2Yrs23bbcPcCTwe0ktwERgrm8Ym5mVV5ZBsBAYLqle0kBgKjB3+8yI2BgRgyOiLiLqgEeApohYlGFNZmbWTmZBEBHbgEuBB8gNZHNHRCyX9E1JTVnt18zMuqerbqh3W0TMA+a1a7uyk2VPyLIWMzPrmN8sNjNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAzCxxDgIzs8Q5CMzMEucgMDNLXKZBIGmypFWS1kia0cH8r0paIWmppN9J+nCW9ZiZ2c76Z7VhSVXA9cApQCuwUNLciFhRsNgTQGNEvCnp88D3gP+eSUFb38p9mZn1VgP2hgHVJd9sZkEATADWRMRzAJLmAFOAHUEQEfMLln8EuCCzah6bCb+9MrPNm5ll7qM/gPEXl3yzWQbBEOCFgulW4CNdLH8xcF9HMyRNA6YBDB06tGfV1B8Hk6/r2bpmZnuCoRMz2WyWQVA0SRcAjcDxHc2PiJnATIDGxsbo0U4OGZv7MjOz98gyCNYChxZM1+bb3kPSycAVwPER8XaG9ZiZWQeyfGpoITBcUr2kgcBUYG7hApLGAj8BmiLi5QxrMTOzTmQWBBGxDbgUeABYCdwREcslfVNSU36xfwU+ANwpaYmkuZ1szszMMpLpPYKImAfMa9d2ZcHnk7Pcv5mZ7ZrfLDYzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBLnIDAzS5yDwMwscQ4CM7PEOQjMzBKniJ6N81IpkjYAz/dw9cHAKyUspzfwMafBx5yG3TnmD0dETUczel0Q7A5JiyKisdJ1lJOPOQ0+5jRkdcy+NGRmljgHgZlZ4lILgpmVLqACfMxp8DGnIZNjTuoegZmZ7Sy1MwIzM2vHQWBmlrhkgkDSZEmrJK2RNKPS9WRN0qGS5ktaIWm5pC9VuqZykFQl6QlJv6p0LeUgaT9Jd0l6WtJKSX9f6ZqyJukr+X/TT0lqllRd6ZpKTdItkl6W9FRB2wGSfitpdf77/qXaXxJBIKkKuB44HRgJnCdpZGWrytw24LKIGAlMBL6QwDEDfAlYWekiyuhHwP0RcThwFH382CUNAf4X0BgRRwJVwNTKVpWJW4HJ7dpmAL+LiOHA7/LTJZFEEAATgDUR8VxEbAHmAFMqXFOmImJ9RDye//w6uV8QQypbVbYk1QIfBW6qdC3lIGkQcBxwM0BEbImI/6poUeXRH9hLUn9gb2BdhespuYhYALzarnkKcFv+823AWaXaXypBMAR4oWC6lT7+S7GQpDpgLPBohUvJ2g+BfwberXAd5VIPbAD+b/5y2E2S3l/porIUEWuB7wN/AdYDGyPiN5WtqmwOjoj1+c8vAgeXasOpBEGyJH0A+Dnw5Yh4rdL1ZEXSx4CXI2JxpWspo/7AOOCGiBgLvEEJLxfsifLXxaeQC8FDgPdLuqCyVZVf5J77L9mz/6kEwVrg0ILp2nxbnyZpALkQmB0Rd1e6noxNApoktZC79HeipJ9WtqTMtQKtEbH9TO8ucsHQl50M/DkiNkTEVuBu4JgK11QuL0n6EED++8ul2nAqQbAQGC6pXtJAcjeX5la4pkxJErlrxysj4geVridrEfH1iKiNiDpy/30fiog+/ZdiRLwIvCDp7/JNJwErKlhSOfwFmChp7/y/8ZPo4zfIC8wFLsx/vhC4t1Qb7l+qDe3JImKbpEuBB8g9ZXBLRCyvcFlZmwR8ClgmaUm+7fKImFe5kiwDXwRm5//AeQ64qML1ZCoiHpV0F/A4uSfjnqAPdjUhqRk4ARgsqRW4CvgucIeki8l1xX9uyfbnLibMzNKWyqUhMzPrhIPAzCxxDgIzs8Q5CMzMEucgMDNLnIPAkiLpQElL8l8vSlqb/7xJ0r9ntM8vS/p0D9YbKGlBvk8ds8z48VFLlqSrgU0R8f0M99Gf3DPv4yJiWw/Wv4pch4mzS16cWZ7PCMwASSdsH8NA0tWSbpP0R0nPSzpb0vckLZN0f77rDiQdLekPkhZLemD76//tnAg8vj0EJP1e0nWSHpP0jKRj8+2j8m1LJC2VNDy//j3A+Zn/ACxpDgKzjg0j90u8CfgpMD8iRgNvAR/Nh8GPgXMi4mjgFuBfOtjOJKB9R3j9I2IC8GVyb4wCfA74UUQ0AI3k+hECeAoYX6JjMuuQrz2adey+iNgqaRm5bknuz7cvA+qAvwOOBH6b6/KGKnLdIrf3IXbuC2d7B4CL89sC+E/givyYCndHxGqAiHhH0hZJ++THlTArOQeBWcfeBoiIdyVtjb/dTHuX3P83ApZHxK6GhnwLaD+U4tv57+/kt0VE3C7pUXID68yT9E8R8VB+ufcBm3fraMy64EtDZj2zCqjZPkawpAGSRnWw3Ergv+1qY5IOA56LiH8j16vkmHz7gcAr+S6XzTLhIDDrgfyQp+cA10l6ElhCx/3i30duOMldORd4Kt9T7JHArHz7PwK/3t16zbrix0fNMibpF8A/b7/u38117wZmRMQzpa/MLMdnBGbZm0HupnG35McYuMchYFnzGYGZWeJ8RmBmljgHgZlZ4hwEZmaJcxCYmSXOQWBmlrj/D7nLZAftp6qcAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from qupulse.pulses.plotting import plot\n",
+    "\n",
+    "_ = plot(constant_template, sample_rate=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/qupulse/_program/waveforms.py
+++ b/qupulse/_program/waveforms.py
@@ -277,7 +277,7 @@ class ConstantWaveform(Waveform):
                       sample_times: np.ndarray,
                       output_array: Union[np.ndarray, None] = None) -> np.ndarray:
         if output_array is None:
-            output_array = np.empty_like(sample_times)
+            output_array = np.empty_like(sample_times, dtype=float)
         output_array[:] = self._amplitude
         return output_array
 

--- a/qupulse/pulses/__init__.py
+++ b/qupulse/pulses/__init__.py
@@ -12,6 +12,7 @@ from qupulse.pulses.mapping_pulse_template import MappingPulseTemplate as Mappin
 from qupulse.pulses.repetition_pulse_template import RepetitionPulseTemplate as RepetitionPT
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate as SequencePT
 from qupulse.pulses.table_pulse_template import TablePulseTemplate as TablePT
+from qupulse.pulses.constant_pulse_template import ConstantPulseTemplate as ConstantPT
 from qupulse.pulses.point_pulse_template import PointPulseTemplate as PointPT
 from qupulse.pulses.arithmetic_pulse_template import ArithmeticPulseTemplate as ArithmeticPT,\
     ArithmeticAtomicPulseTemplate as ArithmeticAtomicPT
@@ -27,5 +28,5 @@ del warnings
 
 
 __all__ = ["FunctionPT", "ForLoopPT", "AtomicMultiChannelPT", "MappingPT", "RepetitionPT", "SequencePT", "TablePT",
-           "PointPT", "AbstractPT", "ParallelConstantChannelPT", "ArithmeticPT", "ArithmeticAtomicPT"]
+           "PointPT", "ConstantPT", "AbstractPT", "ParallelConstantChannelPT", "ArithmeticPT", "ArithmeticAtomicPT"]
 

--- a/qupulse/pulses/constant_pulse_template.py
+++ b/qupulse/pulses/constant_pulse_template.py
@@ -8,15 +8,18 @@ Classes:
 
 from typing import Union, Dict, List, Set, Optional, Any, Tuple, Sequence, NamedTuple, Callable
 import numbers
-
+import logging
 import numpy as np
 
+from qupulse.pulses.pulse_template import ChannelID, Parameter, Transformation, AtomicPulseTemplate, Loop, PulseTemplate
 from qupulse.utils.types import ChannelID
 from qupulse.pulses.parameters import ParameterNotProvidedException, ParameterConstraint, ParameterConstrainer
-from qupulse.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration
+from qupulse.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration, PulseTemplate
 from qupulse._program.waveforms import ConstantWaveform
 from qupulse.expressions import ExpressionScalar
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
+from qupulse.parameter_scope import Scope
+
 
 __all__ = ["ConstantPulseTemplate", "concatenate"]
 
@@ -107,7 +110,7 @@ class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
 
     def build_waveform(self,
                        parameters: Dict[str, numbers.Real],
-                       channel_mapping: Dict[ChannelID, Optional[ChannelID]]) -> Optional[Union[ConstantPulseWaveform,
+                       channel_mapping: Dict[ChannelID, Optional[ChannelID]]) -> Optional[Union[ConstantWaveform,
                                                                                                 MultiChannelWaveform]]:
         logging.debug(f'build_waveform of ConstantPulse: channel_mapping {channel_mapping}, defined_channels {self.defined_channels} ')
         if all(channel_mapping.get(channel, None) is None

--- a/qupulse/pulses/constant_pulse_template.py
+++ b/qupulse/pulses/constant_pulse_template.py
@@ -1,0 +1,124 @@
+"""This module defines the ConstantPulseTemplate, a pulse tempalte representating a pulse with constant values on all channels
+
+Classes:
+    - ConstantPulseTemplate: Defines a pulse via channel-value pairs
+    - ConstantPulseWaveform: A waveform instantiated from a TablePulseTemplate by providing values for its
+        declared parameters.
+"""
+
+from typing import Union, Dict, List, Set, Optional, Any, Tuple, Sequence, NamedTuple, Callable
+import numbers
+
+import numpy as np
+
+from qupulse.utils.types import ChannelID
+from qupulse.pulses.parameters import ParameterNotProvidedException, ParameterConstraint, ParameterConstrainer
+from qupulse.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration
+from qupulse._program.waveforms import ConstantWaveform
+from qupulse.expressions import ExpressionScalar
+from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
+
+__all__ = ["ConstantPulseTemplate", "concatenate"]
+
+
+class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
+
+    def __init__(self, duration: float, amplitude_dict: Dict[str, Any], identifier: Optional[str] = None,
+                 name: Optional[str] = None, measurements: Optional[List[MeasurementDeclaration]] = [], **kwargs: Any) -> None:
+        """ A qupulse waveform representing a single channel with constant value """
+        super().__init__(identifier=identifier, measurements=measurements, **kwargs)
+
+        self._duration = ExpressionScalar(duration)
+        self._amplitude_dict = amplitude_dict
+
+        if name is None:
+            name = 'constant_pulse'
+        self._name = name
+
+    def _as_expression(self):
+        return self._amplitude_dict
+
+    def __str__(self) -> str:
+        return '<{} at %x{}: {}>'.format(self.__class__.__name__, '%x' % id(self), self._name)
+
+    def build_sequence(self) -> None:
+        return
+
+    def get_serialization_data(self) -> Any:
+        data = super().get_serialization_data()
+        data.update({'name': self._name, 'duration': self._duration, '#amplitudes': self._amplitude_dict})
+        return data
+
+    @property
+    def integral(self) -> Dict[ChannelID, ExpressionScalar]:
+        """Returns an expression giving the integral over the pulse."""
+        return {c: self.duration * self._amplitude_dict[c] for c in self._amplitude_dict}
+
+    @property
+    def parameter_names(self) -> Set[str]:
+        """The set of names of parameters required to instantiate this PulseTemplate."""
+        return set()
+
+    @property
+    def is_interruptable(self) -> bool:
+        """Return true, if this PulseTemplate contains points at which it can halt if interrupted.
+        """
+        return False
+
+    @property
+    def duration(self) -> ExpressionScalar:
+        """An expression for the duration of this PulseTemplate."""
+        return (self._duration)
+
+    @property
+    def defined_channels(self) -> Set['ChannelID']:
+        """Returns the number of hardware output channels this PulseTemplate defines."""
+        return set(self._amplitude_dict.keys())
+
+    def requires_stop(self) -> bool:  # from SequencingElement
+        return False
+
+    def _internal_create_program(self, *,
+                                 scope: Scope,
+                                 measurement_mapping: Dict[str, Optional[str]],
+                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
+                                 global_transformation: Optional[Transformation],
+                                 to_single_waveform: Set[Union[str, PulseTemplate]],
+                                 parent_loop: Loop) -> None:
+        """ removed from qupulse docstring """
+        try:
+            parameters = {parameter_name: scope[parameter_name].get_value()
+                          for parameter_name in self.parameter_names}
+        except KeyError as e:
+            raise ParameterNotProvidedException(str(e)) from e
+
+        waveform = self.build_waveform(parameters=parameters,
+                                       channel_mapping=channel_mapping)
+        if waveform:
+            measurements: List[Any] = []
+            measurements = self.get_measurement_windows(parameters=parameters,
+                                                        measurement_mapping=measurement_mapping)
+
+            if global_transformation:
+                waveform = TransformingWaveform(waveform, global_transformation)
+
+            parent_loop.add_measurements(measurements=measurements)
+            parent_loop.append_child(waveform=waveform)
+
+    def build_waveform(self,
+                       parameters: Dict[str, numbers.Real],
+                       channel_mapping: Dict[ChannelID, Optional[ChannelID]]) -> Optional[Union[ConstantPulseWaveform,
+                                                                                                MultiChannelWaveform]]:
+        logging.debug(f'build_waveform of ConstantPulse: channel_mapping {channel_mapping}, defined_channels {self.defined_channels} ')
+        if all(channel_mapping.get(channel, None) is None
+               for channel in self.defined_channels):
+            return None
+
+        
+        waveforms = [ConstantWaveform(self.duration, amplitude, channel)
+                     for channel, amplitude in self._amplitude_dict.items() if channel_mapping[channel] is not None]
+
+        if len(waveforms) == 1:
+            return waveforms.pop()
+        else:
+            return MultiChannelWaveform(waveforms)

--- a/qupulse/pulses/constant_pulse_template.py
+++ b/qupulse/pulses/constant_pulse_template.py
@@ -11,7 +11,7 @@ import numbers
 import logging
 import numpy as np
 
-from qupulse.pulses.pulse_template import ChannelID, Parameter, Transformation, AtomicPulseTemplate, Loop, PulseTemplate
+from qupulse.pulses.pulse_template import ChannelID, Transformation, AtomicPulseTemplate, Loop, PulseTemplate
 from qupulse.utils.types import ChannelID
 from qupulse.pulses.parameters import ParameterNotProvidedException, ParameterConstraint, ParameterConstrainer
 from qupulse.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration, PulseTemplate
@@ -21,14 +21,21 @@ from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
 from qupulse.parameter_scope import Scope
 
 
-__all__ = ["ConstantPulseTemplate", "concatenate"]
+__all__ = ["ConstantPulseTemplate"]
 
 
 class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
 
     def __init__(self, duration: float, amplitude_dict: Dict[str, Any], identifier: Optional[str] = None,
                  name: Optional[str] = None, measurements: Optional[List[MeasurementDeclaration]] = [], **kwargs: Any) -> None:
-        """ A qupulse waveform representing a single channel with constant value """
+        """ A qupulse waveform representing a multi-channel pulse with constant values
+        
+        Args:
+            duration: Duration of the template
+            amplitude_dict: Dictionary with values for the channels
+            name: Name for the template
+        
+        """
         super().__init__(identifier=identifier, measurements=measurements, **kwargs)
 
         self._duration = ExpressionScalar(duration)

--- a/qupulse/pulses/constant_pulse_template.py
+++ b/qupulse/pulses/constant_pulse_template.py
@@ -6,20 +6,19 @@ Classes:
         declared parameters.
 """
 
-from typing import Union, Dict, List, Set, Optional, Any, Tuple, Sequence, NamedTuple, Callable
-import numbers
 import logging
-import numpy as np
+import numbers
+from typing import Any, Dict, List, Optional, Set, Union
 
-from qupulse.pulses.pulse_template import ChannelID, Transformation, AtomicPulseTemplate, Loop, PulseTemplate
-from qupulse.utils.types import ChannelID
-from qupulse.pulses.parameters import ParameterNotProvidedException, ParameterConstraint, ParameterConstrainer
-from qupulse.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration, PulseTemplate
 from qupulse._program.waveforms import ConstantWaveform
 from qupulse.expressions import ExpressionScalar
-from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
 from qupulse.parameter_scope import Scope
-
+from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
+from qupulse.pulses.parameters import ParameterNotProvidedException
+from qupulse.pulses.pulse_template import (AtomicPulseTemplate, ChannelID,
+                                           Loop, MeasurementDeclaration,
+                                           PulseTemplate, Transformation,
+                                           TransformingWaveform)
 
 __all__ = ["ConstantPulseTemplate"]
 

--- a/tests/_program/waveforms_tests.py
+++ b/tests/_program/waveforms_tests.py
@@ -345,10 +345,10 @@ class ConstantWaveformTests(unittest.TestCase):
         self.assertEqual(waveform.duration, 10)
 
     def test_waveform_sample(self):
-        waveform = ConstantWaveform(10, 1.1, 'P1')
+        waveform = ConstantWaveform(10, .1, 'P1')
         sample_times = [-1, 0, 1, 2]
         result = waveform.unsafe_sample('P1', sample_times)
-        self.assertTrue(np.all(result == 1.1))
+        self.assertTrue(np.all(result == .1))
 
 
 class TableWaveformTests(unittest.TestCase):

--- a/tests/_program/waveforms_tests.py
+++ b/tests/_program/waveforms_tests.py
@@ -8,7 +8,7 @@ from qupulse.utils.types import TimeType
 from qupulse.pulses.interpolation import HoldInterpolationStrategy, LinearInterpolationStrategy,\
     JumpInterpolationStrategy
 from qupulse._program.waveforms import MultiChannelWaveform, RepetitionWaveform, SequenceWaveform,\
-    TableWaveformEntry, TableWaveform, TransformingWaveform, SubsetWaveform, ArithmeticWaveform
+    TableWaveformEntry, TableWaveform, TransformingWaveform, SubsetWaveform, ArithmeticWaveform, ConstantWaveform
 from qupulse._program.transformation import Transformation
 
 from tests.pulses.sequencing_dummies import DummyWaveform, DummyInterpolationStrategy
@@ -30,8 +30,8 @@ class WaveformTest(unittest.TestCase):
             wf.get_sampled(channel='A',
                            sample_times=numpy.asarray([-12, 1], dtype=float))
         with self.assertRaises(KeyError):
-                wf.get_sampled(channel='C',
-                               sample_times=numpy.asarray([0.5, 1], dtype=float))
+            wf.get_sampled(channel='C',
+                           sample_times=numpy.asarray([0.5, 1], dtype=float))
         with self.assertRaises(ValueError):
             wf.get_sampled(channel='A',
                            sample_times=numpy.asarray([0.5, 1], dtype=float),
@@ -299,7 +299,8 @@ class SequenceWaveformTest(unittest.TestCase):
             expected_inputs = sample_times[0:10], sample_times[10:40] - 1, sample_times[40:] - 4
 
             swf.unsafe_sample('A', sample_times=sample_times)
-            inputs = [call_args[1]['sample_times'] for call_args in unsafe_sample_patch.call_args_list] # type: List[np.ndarray]
+            inputs = [call_args[1]['sample_times']
+                      for call_args in unsafe_sample_patch.call_args_list]  # type: List[np.ndarray]
             np.testing.assert_equal(expected_inputs, inputs)
             self.assertEqual([input.dtype for input in inputs], [np.float64 for _ in inputs])
 
@@ -337,6 +338,18 @@ class SequenceWaveformTest(unittest.TestCase):
         self.assertEqual(sub_wf.compare_key[1].duration, TimeType.from_float(3.3))
 
 
+class ConstantWaveformTests(unittest.TestCase):
+
+    def test_waveform_duration(self):
+        waveform = ConstantWaveform(10, 1., 'P1')
+        self.assertEqual(waveform.duration, 10)
+
+    def test_waveform_sample(self):
+        waveform = ConstantWaveform(10, 1.1, 'P1')
+        sample_times = [-1, 0, 1, 2]
+        result = waveform.unsafe_sample('P1', sample_times)
+        self.assertTrue(np.all(result == 1.1))
+
 
 class TableWaveformTests(unittest.TestCase):
 
@@ -370,10 +383,9 @@ class TableWaveformTests(unittest.TestCase):
                                      TableWaveformEntry(0.1, 0.3, HoldInterpolationStrategy()),
                                      TableWaveformEntry(0.3, 0.3, JumpInterpolationStrategy())))
 
-
-
     def test_duration(self) -> None:
-        entries = [TableWaveformEntry(0, 0, HoldInterpolationStrategy()), TableWaveformEntry(5, 1, HoldInterpolationStrategy())]
+        entries = [TableWaveformEntry(0, 0, HoldInterpolationStrategy()),
+                   TableWaveformEntry(5, 1, HoldInterpolationStrategy())]
         waveform = TableWaveform('A', entries)
         self.assertEqual(5, waveform.duration)
 

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -1,0 +1,61 @@
+import unittest
+
+import qupulse.pulses.plotting
+from qupulse.pulses import TablePT, FunctionPT, AtomicMultiChannelPT, MappingPT
+from qupulse.pulses.plotting import render, plot
+from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate
+from qupulse._program._loop import make_compatible
+
+from qupulse.pulses.constant_pulse_template import ConstantPulseTemplate
+#, AtomicSequencePulseTemplate, create_multichannel_pulse, MethodPulseTemplate
+
+class TestConstantPulseTemplate(unittest.TestCase):
+
+    def test_ConstantPulseTemplate(self):
+        pt = ConstantPulseTemplate(100, {'P1': .5, 'P2': .25})
+        self.assertEqual(pt.integral, {'P1': 50, 'P2': 25})
+
+    def test_zero_duration(self):
+        p1 = ConstantPulseTemplate(10, {'P1': 1.})
+        p2 = ConstantPulseTemplate(0, {'P1': 1.})
+        p3 = ConstantPulseTemplate(2, {'P1': 1.})
+
+        _ = qupulse.pulses.plotting.render(p1.create_program())
+
+        pulse = AtomicSequencePulseTemplate([p1, p2, p3])
+        prog = pulse.create_program()
+        _ = qupulse.pulses.plotting.render(prog)
+
+        self.assertEqual(pulse.duration, 12)
+
+    def test_regression_duration_conversion(self):
+        for duration_in_samples in [64, 936320, 24615392]:
+            p = ConstantPulseTemplate(duration_in_samples / 2.4, {'a': 0})
+            number_of_samples = p.create_program().duration * 2.4
+            make_compatible(p.create_program(), 8, 8, 2.4)
+            self.assertEqual(number_of_samples.denominator, 1)
+
+            p2 = ConstantPulseTemplate((duration_in_samples +1) / 2.4, {'a': 0})
+            self.assertNotEqual(p.create_program().duration, p2.create_program().duration)
+
+    def test_regression_duration_conversion_functionpt(self):
+        for duration_in_samples in [64, 2000, 936320]:
+            p = FunctionPT('1', duration_expression=duration_in_samples / 2.4, channel='a')
+            number_of_samples = p.create_program().duration * 2.4
+            self.assertEqual(number_of_samples.denominator, 1)
+
+    def test_regression_template_combination(self):
+        duration_in_seconds = 2e-6
+        full_template = ConstantPulseTemplate(duration=duration_in_seconds * 1e9, amplitude_dict={'C1': 1.1})
+        duration_in_seconds_derived = 1e-9 * full_template.duration
+        marker_pulse = TablePT({'marker': [(0, 0), (duration_in_seconds_derived * 1e9, 0)]})
+        full_template = AtomicMultiChannelPT(full_template, marker_pulse)
+
+    def test_regression_sequencept_with_mappingpt(self):
+        t1 = TablePT({'C1': [(0, 0), (100, 0)], 'C2': [(0, 1), (100, 1)]})
+        t2 = ConstantPulseTemplate(200, {'C1': 2, 'C2': 3})
+        qupulse_template = SequencePulseTemplate(t1, t2)
+        channel_mapping = {'C1': None, 'C2': 'C2'}
+        p = MappingPT(qupulse_template, channel_mapping=channel_mapping)
+        plot(p)
+        self.assertEqual(p.defined_channels, {'C2'})

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -1,6 +1,7 @@
 import unittest
 
 import qupulse.pulses.plotting
+import qupulse._program.waveforms
 from qupulse.pulses import TablePT, FunctionPT, AtomicMultiChannelPT, MappingPT
 from qupulse.pulses.plotting import plot
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate
@@ -28,27 +29,45 @@ class TestConstantPulseTemplate(unittest.TestCase):
         self.assertEqual(pulse.duration, 12)
 
     def test_regression_duration_conversion(self):
-        for duration_in_samples in [64, 936320, 24615392]:
-            p = ConstantPulseTemplate(duration_in_samples / 2.4, {'a': 0})
-            number_of_samples = p.create_program().duration * 2.4
-            make_compatible(p.create_program(), 8, 8, 2.4)
-            self.assertEqual(number_of_samples.denominator, 1)
+        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR 
 
-            p2 = ConstantPulseTemplate((duration_in_samples +1) / 2.4, {'a': 0})
-            self.assertNotEqual(p.create_program().duration, p2.create_program().duration)
+        try:
+            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
+            for duration_in_samples in [64, 936320, 24615392]:
+                p = ConstantPulseTemplate(duration_in_samples / 2.4, {'a': 0})
+                number_of_samples = p.create_program().duration * 2.4
+                make_compatible(p.create_program(), 8, 8, 2.4)
+                self.assertEqual(number_of_samples.denominator, 1)
+    
+                p2 = ConstantPulseTemplate((duration_in_samples +1) / 2.4, {'a': 0})
+                self.assertNotEqual(p.create_program().duration, p2.create_program().duration)
+        finally:
+            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_duration_conversion_functionpt(self):
-        for duration_in_samples in [64, 2000, 936320]:
-            p = FunctionPT('1', duration_expression=duration_in_samples / 2.4, channel='a')
-            number_of_samples = p.create_program().duration * 2.4
-            self.assertEqual(number_of_samples.denominator, 1)
+        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR 
+
+        try:
+            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
+            for duration_in_samples in [64, 2000, 936320]:
+                p = FunctionPT('1', duration_expression=duration_in_samples / 2.4, channel='a')
+                number_of_samples = p.create_program().duration * 2.4
+                self.assertEqual(number_of_samples.denominator, 1)
+        finally:
+            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_template_combination(self):
-        duration_in_seconds = 2e-6
-        full_template = ConstantPulseTemplate(duration=duration_in_seconds * 1e9, amplitude_dict={'C1': 1.1})
-        duration_in_seconds_derived = 1e-9 * full_template.duration
-        marker_pulse = TablePT({'marker': [(0, 0), (duration_in_seconds_derived * 1e9, 0)]})
-        full_template = AtomicMultiChannelPT(full_template, marker_pulse)
+        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR 
+
+        try:
+            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
+            duration_in_seconds = 2e-6
+            full_template = ConstantPulseTemplate(duration=duration_in_seconds * 1e9, amplitude_dict={'C1': 1.1})
+            duration_in_seconds_derived = 1e-9 * full_template.duration
+            marker_pulse = TablePT({'marker': [(0, 0), (duration_in_seconds_derived * 1e9, 0)]})
+            full_template = AtomicMultiChannelPT(full_template, marker_pulse)
+        finally:
+            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_sequencept_with_mappingpt(self):
         t1 = TablePT({'C1': [(0, 0), (100, 0)], 'C2': [(0, 1), (100, 1)]})

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -2,6 +2,7 @@ import unittest
 
 import qupulse.pulses.plotting
 import qupulse._program.waveforms
+import qupulse.utils.sympy
 from qupulse.pulses import TablePT, FunctionPT, AtomicMultiChannelPT, MappingPT
 from qupulse.pulses.plotting import plot
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate
@@ -57,17 +58,17 @@ class TestConstantPulseTemplate(unittest.TestCase):
             qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_template_combination(self):
-        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR 
+        old_value = qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN
 
         try:
-            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
+            qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN = 1e-9
             duration_in_seconds = 2e-6
             full_template = ConstantPulseTemplate(duration=duration_in_seconds * 1e9, amplitude_dict={'C1': 1.1})
             duration_in_seconds_derived = 1e-9 * full_template.duration
             marker_pulse = TablePT({'marker': [(0, 0), (duration_in_seconds_derived * 1e9, 0)]})
             full_template = AtomicMultiChannelPT(full_template, marker_pulse)
         finally:
-            qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
+            qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN = old_value
 
     def test_regression_sequencept_with_mappingpt(self):
         t1 = TablePT({'C1': [(0, 0), (100, 0)], 'C2': [(0, 1), (100, 1)]})

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -2,12 +2,11 @@ import unittest
 
 import qupulse.pulses.plotting
 from qupulse.pulses import TablePT, FunctionPT, AtomicMultiChannelPT, MappingPT
-from qupulse.pulses.plotting import render, plot
+from qupulse.pulses.plotting import plot
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate
 from qupulse._program._loop import make_compatible
 
 from qupulse.pulses.constant_pulse_template import ConstantPulseTemplate
-#, AtomicSequencePulseTemplate, create_multichannel_pulse, MethodPulseTemplate
 
 class TestConstantPulseTemplate(unittest.TestCase):
 
@@ -22,7 +21,7 @@ class TestConstantPulseTemplate(unittest.TestCase):
 
         _ = qupulse.pulses.plotting.render(p1.create_program())
 
-        pulse = AtomicSequencePulseTemplate([p1, p2, p3])
+        pulse = SequencePulseTemplate(p1, p2, p3)
         prog = pulse.create_program()
         _ = qupulse.pulses.plotting.render(prog)
 

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -10,11 +10,18 @@ from qupulse._program._loop import make_compatible
 
 from qupulse.pulses.constant_pulse_template import ConstantPulseTemplate
 
+
 class TestConstantPulseTemplate(unittest.TestCase):
 
     def test_ConstantPulseTemplate(self):
         pt = ConstantPulseTemplate(100, {'P1': .5, 'P2': .25})
         self.assertEqual(pt.integral, {'P1': 50, 'P2': 25})
+
+        data = pt.get_serialization_data()
+        self.assertEqual(data['name'], pt._name)
+
+        self.assertIn('ConstantPulseTemplate', str(pt))
+        self.assertIn('ConstantPulseTemplate', repr(pt))
 
     def test_zero_duration(self):
         p1 = ConstantPulseTemplate(10, {'P1': 1.})
@@ -30,7 +37,7 @@ class TestConstantPulseTemplate(unittest.TestCase):
         self.assertEqual(pulse.duration, 12)
 
     def test_regression_duration_conversion(self):
-        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR 
+        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR
 
         try:
             qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
@@ -39,14 +46,14 @@ class TestConstantPulseTemplate(unittest.TestCase):
                 number_of_samples = p.create_program().duration * 2.4
                 make_compatible(p.create_program(), 8, 8, 2.4)
                 self.assertEqual(number_of_samples.denominator, 1)
-    
-                p2 = ConstantPulseTemplate((duration_in_samples +1) / 2.4, {'a': 0})
+
+                p2 = ConstantPulseTemplate((duration_in_samples + 1) / 2.4, {'a': 0})
                 self.assertNotEqual(p.create_program().duration, p2.create_program().duration)
         finally:
             qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_duration_conversion_functionpt(self):
-        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR 
+        old_value = qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR
 
         try:
             qupulse._program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6


### PR DESCRIPTION
Add template for multi-channel pulses that are constant. These pulses are easier to create than a `TablePulseTemplate` and allow backends to optimize uploaded of these waveforms.

@terrorfisch 