### PR TITLE
Fix pip install from git

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 author = Quantum Technology Group and Chair of Software Engineering, RWTH Aachen University
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 keywords = quantum, physics, control pulse, qubit
 classifiers =
           Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,9 +48,11 @@ zurich-instruments = zhinst
 Faster-fractions = gmpy2
 tektronix = tek_awg>=0.2.1
 
-
 [options.packages.find]
-include = qupulse* qctoolkit*
+include =
+    qupulse
+    qupulse.*
+    qctoolkit
 
 [tool:pytest]
 testpaths = tests tests/pulses tests/hardware tests/backward_compatibility


### PR DESCRIPTION
The PEP517 build did not include any packages because the `find` include argument was specified with space as delimiter.

@peendebak 