### PR TITLE
Performance improvements

### DIFF
--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -103,8 +103,10 @@ class Expression(AnonymousSerializable, metaclass=_ExpressionMeta):
         else:
             e = self.evaluate_numeric()
             return float(e)
-    
+
     def evaluate_symbolic(self, substitutions: Mapping[Any, Any]) -> 'Expression':
+        if len(substitutions)==0:
+            return self.underlying_expression
         return Expression.make(recursive_substitution(sympify(self.underlying_expression), substitutions))
 
     @property

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -248,7 +248,7 @@ class ExpressionScalar(Expression):
         super().__init__()
 
         if isinstance(ex, sympy.Expr):
-            self._original_expression = str(ex)
+            self._original_expression = ex
             self._sympified_expression = ex
         else:
             self._original_expression = ex


### PR DESCRIPTION
* Skip substituation for empty mapping
* Do not convert to `str` for `_original_expression`

@terrorfisch 