### PR TITLE
Dynamic loop insertion

### DIFF
--- a/changes.d/622.feature
+++ b/changes.d/622.feature
@@ -1,0 +1,2 @@
+Add option to automatically reduce the sample rate of HDAWG playback for piecewise constant pulses.
+Use `qupulse._program.seqc.WaveformPlayback.ENABLE_DYNAMIC_RATE_REDUCTION` to enable it.

--- a/qupulse/_program/_loop.py
+++ b/qupulse/_program/_loop.py
@@ -624,7 +624,7 @@ def roll_constant_waveforms(program: Loop, minimal_waveform_quanta: int, wavefor
         additional_repetition_count = waveform_quanta // new_waveform_quanta
 
         new_waveform = ConstantWaveform.from_mapping(
-            duration=new_waveform_quanta / sample_rate,
+            duration=waveform_quantum * new_waveform_quanta / sample_rate,
             constant_values=const_values)
 
         # use the private properties to avoid invalidating the duration cache of the parent loop

--- a/qupulse/_program/_loop.py
+++ b/qupulse/_program/_loop.py
@@ -2,16 +2,18 @@ from typing import Union, Dict, Iterable, Tuple, cast, List, Optional, Generator
 from collections import defaultdict
 from enum import Enum
 import warnings
+import bisect
 
 import numpy as np
+import sympy.ntheory
 
-
-from qupulse._program.waveforms import Waveform
+from qupulse._program.waveforms import Waveform, ConstantWaveform
 from qupulse._program.volatile import VolatileRepetitionCount, VolatileProperty
 
 from qupulse.utils import is_integer
 from qupulse.utils.types import TimeType, MeasurementWindow
 from qupulse.utils.tree import Node, is_tree_circular
+from qupulse.utils.numeric import smallest_factor_ge
 
 from qupulse._program.waveforms import SequenceWaveform, RepetitionWaveform
 
@@ -576,6 +578,58 @@ def make_compatible(program: Loop, minimal_waveform_length: int, waveform_quantu
 
     else:
         assert comp_level == _CompatibilityLevel.compatible
+
+
+def roll_constant_waveforms(program: Loop, minimal_waveform_quanta: int, waveform_quantum: int, sample_rate: TimeType):
+    """This function finds waveforms in program that can be replaced with repetitions of shorter waveforms and replaces
+    them. Complexity O(N_waveforms)
+
+    This is possible if:
+     - The waveform is constant on all channels
+     - waveform.duration * sample_rate / waveform_quantum has a factor that is bigger than minimal_waveform_quanta
+
+    Args:
+        program:
+        minimal_waveform_quanta:
+        waveform_quantum:
+        sample_rate:
+    """
+    waveform = program.waveform
+
+    if waveform is None:
+        for child in program:
+            roll_constant_waveforms(child, minimal_waveform_quanta, waveform_quantum, sample_rate)
+    else:
+        waveform_quanta = (waveform.duration * sample_rate) // waveform_quantum
+
+        # example
+        # waveform_quanta = 15
+        # minimal_waveform_quanta = 2
+        # => repetition_count = 5, new_waveform_quanta = 3
+        if waveform_quanta < minimal_waveform_quanta * 2:
+            # there is no way to roll this waveform because it is too short
+            return
+
+        const_values = waveform.constant_value_dict()
+        if const_values is None:
+            # The waveform is not constant
+            return
+
+        new_waveform_quanta = smallest_factor_ge(waveform_quanta, min_factor=minimal_waveform_quanta)
+        if new_waveform_quanta == waveform_quanta:
+            # the waveform duration in samples has no suitable factor
+            # TODO: Option to insert multiple Loop objects
+            return
+
+        additional_repetition_count = waveform_quanta // new_waveform_quanta
+
+        new_waveform = ConstantWaveform.from_mapping(
+            duration=new_waveform_quanta / sample_rate,
+            constant_values=const_values)
+
+        # use the private properties to avoid invalidating the duration cache of the parent loop
+        program._repetition_definition = program.repetition_definition * additional_repetition_count
+        program._waveform = new_waveform
 
 
 class MakeCompatibleWarning(ResourceWarning):

--- a/qupulse/_program/volatile.py
+++ b/qupulse/_program/volatile.py
@@ -62,3 +62,9 @@ class VolatileRepetitionCount(VolatileValue):
     def update_volatile_dependencies(self, new_constants: Mapping[str, numbers.Number]) -> int:
         self._scope = self._scope.change_constants(new_constants)
         return int(self)
+
+    def __eq__(self, other):
+        if type(self) == type(other):
+            return self._scope is other._scope and self._expression == other._expression
+        else:
+            return NotImplemented

--- a/qupulse/utils/numeric.py
+++ b/qupulse/utils/numeric.py
@@ -1,11 +1,37 @@
 from typing import Tuple, Type
 from numbers import Rational
 from math import gcd
+from operator import le
+from functools import partial
+
+import sympy
 
 
 def lcm(a: int, b: int):
     """least common multiple"""
     return a * b // gcd(a, b)
+
+
+def smallest_factor_ge(n: int, min_factor: int, brute_force: int = 5):
+    """Find the smallest factor of n that is greater or equal min_factor
+
+    Args:
+        n: number to factorize
+        min_factor: factor must be larger this
+        brute_force: range(min_factor, min(min_factor + brute_force)) is probed by brute force
+
+    Returns:
+        Smallest factor of n that is greater or equal min_factor
+    """
+    assert min_factor <= n
+
+    # this shortcut force shortcut costs 1us max
+    for factor in range(min_factor, min(min_factor + brute_force, n)):
+        if n % factor == 0:
+            return factor
+    else:
+        return min(filter(partial(le, min_factor),
+                          sympy.ntheory.divisors(n, generator=True)))
 
 
 def _approximate_int(alpha_num: int, d_num: int, den: int) -> Tuple[int, int]:

--- a/tests/_program/loop_tests.py
+++ b/tests/_program/loop_tests.py
@@ -478,3 +478,7 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
 
                 is_compat.assert_called_once_with(program, **priv_kwargs)
                 make_compat.assert_called_once_with(program, **priv_kwargs)
+
+    def test_roll_constant_waveforms(self):
+        raise NotImplementedError()
+

--- a/tests/_program/loop_tests.py
+++ b/tests/_program/loop_tests.py
@@ -1,6 +1,9 @@
+import copy
 import unittest
 from unittest import mock
 import itertools
+
+import numpy as np
 
 from string import ascii_uppercase
 
@@ -10,9 +13,10 @@ from qupulse.parameter_scope import DictScope
 from qupulse.utils.types import TimeType, time_from_float
 from qupulse._program.volatile import VolatileRepetitionCount
 from qupulse._program._loop import Loop, _make_compatible, _is_compatible, _CompatibilityLevel,\
-    RepetitionWaveform, SequenceWaveform, make_compatible, MakeCompatibleWarning, DroppedMeasurementWarning, VolatileModificationWarning
+    RepetitionWaveform, SequenceWaveform, make_compatible, MakeCompatibleWarning, DroppedMeasurementWarning,\
+    VolatileModificationWarning, roll_constant_waveforms
 from qupulse._program._loop import Loop, _make_compatible, _is_compatible, _CompatibilityLevel,\
-    RepetitionWaveform, SequenceWaveform, make_compatible, MakeCompatibleWarning
+    RepetitionWaveform, SequenceWaveform, make_compatible, MakeCompatibleWarning, ConstantWaveform
 from tests.pulses.sequencing_dummies import DummyWaveform
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
 
@@ -480,5 +484,57 @@ class ProgramWaveformCompatibilityTest(unittest.TestCase):
                 make_compat.assert_called_once_with(program, **priv_kwargs)
 
     def test_roll_constant_waveforms(self):
-        raise NotImplementedError()
+        root = Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.5}), repetition_count=4)
+        expected = copy.deepcopy(root)
+        roll_constant_waveforms(root, 1, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
 
+        root = Loop(waveform=ConstantWaveform.from_mapping(32, {'A': 1., 'B': 0.5}), repetition_count=4)
+        expected = Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.5}), repetition_count=8)
+        roll_constant_waveforms(root, 1, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
+
+        root = Loop(waveform=ConstantWaveform.from_mapping(16*3, {'A': 1., 'B': 0.5}), repetition_count=4)
+        expected = Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.5}), repetition_count=12)
+        roll_constant_waveforms(root, 1, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
+
+        root = Loop(waveform=ConstantWaveform.from_mapping(16*3, {'A': 1., 'B': 0.5}), repetition_count=4)
+        expected = copy.deepcopy(root)
+        roll_constant_waveforms(root, 2, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
+
+        root = Loop(waveform=ConstantWaveform.from_mapping(16*5, {'A': 1., 'B': 0.5}), repetition_count=4)
+        expected = copy.deepcopy(root)
+        roll_constant_waveforms(root, 2, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
+
+        root = Loop(children=[
+            Loop(waveform=ConstantWaveform.from_mapping(32, {'A': 1., 'B': 0.5}), repetition_count=4),
+            Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.3}), repetition_count=4),
+            Loop(waveform=ConstantWaveform.from_mapping(128, {'A': .1, 'B': 0.5}), repetition_count=2)
+        ])
+        expected = Loop(children=[
+            Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.5}), repetition_count=8),
+            Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.3}), repetition_count=4),
+            Loop(waveform=ConstantWaveform.from_mapping(16, {'A': .1, 'B': 0.5}), repetition_count=2*128//16)
+        ])
+        roll_constant_waveforms(root, 1, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
+
+        not_constant_wf = DummyWaveform(sample_output=np.array([.1, .2, .3]),
+                                        duration=TimeType.from_fraction(32, 1),
+                                        defined_channels={'A', 'B'})
+
+        root = Loop(waveform=not_constant_wf, repetition_count=4)
+        expected = copy.deepcopy(root)
+        roll_constant_waveforms(root, 1, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)
+
+        scope = DictScope.from_mapping({'a': 4, 'b': 3}, volatile={'a'})
+        rep_count = VolatileRepetitionCount(expression=ExpressionScalar('a+b'), scope=scope)
+        root = Loop(waveform=ConstantWaveform.from_mapping(32, {'A': 1., 'B': 0.5}), repetition_count=rep_count)
+        expected = Loop(waveform=ConstantWaveform.from_mapping(16, {'A': 1., 'B': 0.5}), repetition_count=rep_count * 2)
+        self.assertNotEqual(root.repetition_count, expected.repetition_count)
+        roll_constant_waveforms(root, 1, 16, TimeType.from_fraction(1, 1))
+        self.assertEqual(root, expected)

--- a/tests/_program/seqc_tests.py
+++ b/tests/_program/seqc_tests.py
@@ -31,6 +31,35 @@ def take(n, iterable):
     return list(islice(iterable, n))
 
 
+class BinaryWaveformTest(unittest.TestCase):
+    MAX_RATE = 14
+
+    def test_dynamic_rate_reduction(self):
+
+        ones = np.ones(2**(self.MAX_RATE + 2) * 3, np.uint16)
+        zeros = np.zeros(2**(self.MAX_RATE + 2) * 3, np.uint16)
+        irreducibles = [
+            np.array([0, 0, 1, 1, 0, 1] * 16, dtype=np.uint16),
+            np.array([0, 0, 0] * 16 + [0, 1, 0] + [0, 0, 0] * 15, dtype=np.uint16),
+            np.array([0, 0, 0] * 16 + [1, 0, 0] + [0, 0, 0] * 15, dtype=np.uint16),
+        ]
+
+        for max_rate in range(self.MAX_RATE):
+            self.assertEqual(BinaryWaveform(ones[:32 * 3]).dynamic_rate(max_rate=max_rate), 0)
+            self.assertEqual(BinaryWaveform(ones[:(32 + 16) * 3]).dynamic_rate(max_rate=max_rate), 0)
+
+            for n in range(self.MAX_RATE):
+                for irreducible in irreducibles:
+                    data = np.tile(np.tile(irreducible.reshape(-1, 1, 3), (1, 2**n, 1)).ravel(), (16,))
+
+                    dyn_n = BinaryWaveform(data).dynamic_rate(max_rate=max_rate)
+
+                    self.assertEqual(min(max_rate, n), dyn_n)
+
+
+
+
+
 def make_binary_waveform(waveform):
     if waveform.duration == 0:
         data = np.asarray(3 * [1, 2, 3, 4, 5], dtype=np.uint16)

--- a/tests/_program/seqc_tests.py
+++ b/tests/_program/seqc_tests.py
@@ -112,9 +112,10 @@ def get_constant_unique_wfs(n=10000, duration=192, defined_channels=frozenset(['
 
         random_values = rng.random(size=(n, len(defined_channels)))
 
+        sorted_channels = sorted(defined_channels)
         get_unique_wfs.cache[key] = [
-            ConstantWaveform.from_mapping(duration, {ch: rng.random()
-                                                     for ch, ch_value in zip(defined_channels, wf_values)})
+            ConstantWaveform.from_mapping(duration, {ch: ch_value
+                                                     for ch, ch_value in zip(sorted_channels, wf_values)})
             for wf_values in random_values
         ]
     return get_unique_wfs.cache[key]
@@ -958,7 +959,7 @@ const PLAYBACK_FINISHED_MASK = 0b1000000000000000000000000000000;
 const PROG_SEL_MASK = 0b111111111111111111111111111111;
 const INVERTED_PROG_SEL_MASK = 0b11000000000000000000000000000000;
 const IDLE_WAIT_CYCLES = 300;
-wave test_concatenated_waveform_0 = "9d22a3c2fc392dc5208eec6140fce5d4b766d583ef428cc640d69c4c41475902";
+wave test_concatenated_waveform_0 = "7fd412eb866ad371f717857ea33b309ec458c6c3469c7e51dcffcdce9a8c2679";
 wave test_shared_waveform_121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518 = "121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518";
 
 // function used by manually triggered programs

--- a/tests/_program/seqc_tests.py
+++ b/tests/_program/seqc_tests.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import pathlib
 import hashlib
+import random
 
 import numpy as np
 
@@ -13,6 +14,7 @@ from qupulse.expressions import ExpressionScalar
 from qupulse.parameter_scope import DictScope
 
 from qupulse._program._loop import Loop
+from qupulse._program.waveforms import ConstantWaveform
 from qupulse._program.seqc import BinaryWaveform, loop_to_seqc, WaveformPlayback, Repeat, SteppingRepeat, Scope,\
     to_node_clusters, find_sharable_waveforms, mark_sharable_waveforms, UserRegisterManager, HDAWGProgramManager,\
     UserRegister, WaveformFileSystem
@@ -37,17 +39,18 @@ class BinaryWaveformTest(unittest.TestCase):
     def test_dynamic_rate_reduction(self):
 
         ones = np.ones(2**(self.MAX_RATE + 2) * 3, np.uint16)
-        zeros = np.zeros(2**(self.MAX_RATE + 2) * 3, np.uint16)
+
+        for n in (2, 3, 5):
+            self.assertEqual(BinaryWaveform(ones[:n * 16 * 3]).dynamic_rate(), 0, f"Reducing {n}")
+        for n in (4, 6):
+            self.assertEqual(BinaryWaveform(ones[:16 * n * 3]).dynamic_rate(), 1)
+
         irreducibles = [
             np.array([0, 0, 1, 1, 0, 1] * 16, dtype=np.uint16),
             np.array([0, 0, 0] * 16 + [0, 1, 0] + [0, 0, 0] * 15, dtype=np.uint16),
             np.array([0, 0, 0] * 16 + [1, 0, 0] + [0, 0, 0] * 15, dtype=np.uint16),
         ]
-
         for max_rate in range(self.MAX_RATE):
-            self.assertEqual(BinaryWaveform(ones[:32 * 3]).dynamic_rate(max_rate=max_rate), 0)
-            self.assertEqual(BinaryWaveform(ones[:(32 + 16) * 3]).dynamic_rate(max_rate=max_rate), 0)
-
             for n in range(self.MAX_RATE):
                 for irreducible in irreducibles:
                     data = np.tile(np.tile(irreducible.reshape(-1, 1, 3), (1, 2**n, 1)).ravel(), (16,))
@@ -55,9 +58,6 @@ class BinaryWaveformTest(unittest.TestCase):
                     dyn_n = BinaryWaveform(data).dynamic_rate(max_rate=max_rate)
 
                     self.assertEqual(min(max_rate, n), dyn_n)
-
-
-
 
 
 def make_binary_waveform(waveform):
@@ -90,6 +90,24 @@ def get_unique_wfs(n=10000, duration=32, defined_channels=frozenset(['A'])):
             DummyWaveform(duration=duration, sample_output=base[idx:idx+duration],
                           defined_channels=defined_channels)
             for idx in range(n)
+        ]
+    return get_unique_wfs.cache[key]
+
+
+def get_constant_unique_wfs(n=10000, duration=192, defined_channels=frozenset(['A'])):
+    if not hasattr(get_unique_wfs, 'cache'):
+        get_unique_wfs.cache = {}
+
+    key = (n, duration)
+
+    if key not in get_unique_wfs.cache:
+        rng = random.Random(str(key).encode('ascii'))
+
+        # positive deterministic int64
+
+        get_unique_wfs.cache[key] = [
+            ConstantWaveform.from_mapping(duration, {ch: rng.random() for ch in defined_channels})
+            for _ in range(n)
         ]
     return get_unique_wfs.cache[key]
 
@@ -887,3 +905,135 @@ while (true) {
 }"""
         self.assertEqual(expected_program, seqc_program)
 
+    @unittest.skipIf(sys.version_info.minor < 6, "This test requires dict to be ordered.")
+    def test_full_run_with_dynamic_rate_reduction(self):
+        defined_channels = frozenset(['A', 'B', 'C'])
+
+        unique_n = 1000
+        unique_duration = 192
+
+        unique_wfs = get_constant_unique_wfs(n=unique_n, duration=unique_duration,
+                                             defined_channels=defined_channels)
+        same_wf = DummyWaveform(duration=48, sample_output=np.ones(48), defined_channels=defined_channels)
+
+        channels = ('A', 'B')
+        markers = ('C', None, 'A', None)
+        amplitudes = (1., 1.)
+        offsets = (0., 0.)
+        volatage_transformations = (lambda x: x, lambda x: x)
+        sample_rate = 1
+
+        old_value, WaveformPlayback.ENABLE_DYNAMIC_RATE_REDUCTION = WaveformPlayback.ENABLE_DYNAMIC_RATE_REDUCTION, True
+        try:
+            root = complex_program_as_loop(unique_wfs, wf_same=same_wf)
+            seqc_nodes = complex_program_as_seqc(unique_wfs, wf_same=same_wf)
+
+            manager = HDAWGProgramManager()
+
+            manager.add_program('test', root, channels, markers, amplitudes, offsets, volatage_transformations,
+                                sample_rate)
+        finally:
+            WaveformPlayback.ENABLE_DYNAMIC_RATE_REDUCTION = old_value
+
+
+
+        # 0: Program selection
+        # 1: Trigger
+        self.assertEqual({UserRegister(zero_based_value=2): 7}, manager.get_register_values('test'))
+        seqc_program = manager.to_seqc_program()
+        expected_program = """const PROG_SEL_REGISTER = 0;
+const TRIGGER_REGISTER = 1;
+const TRIGGER_RESET_MASK = 0b10000000000000000000000000000000;
+const PROG_SEL_NONE = 0;
+const NO_RESET_MASK = 0b10000000000000000000000000000000;
+const PLAYBACK_FINISHED_MASK = 0b1000000000000000000000000000000;
+const PROG_SEL_MASK = 0b111111111111111111111111111111;
+const INVERTED_PROG_SEL_MASK = 0b11000000000000000000000000000000;
+const IDLE_WAIT_CYCLES = 300;
+wave test_concatenated_waveform_0 = "808fb305aa38f44d55a59792a032696d28244040f86ec35e828c829eade2b79f";
+wave test_shared_waveform_121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518 = "121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518";
+
+// function used by manually triggered programs
+void waitForSoftwareTrigger() {
+  while (true) {
+    var trigger_register = getUserReg(TRIGGER_REGISTER);
+    if (trigger_register & TRIGGER_RESET_MASK) setUserReg(TRIGGER_REGISTER, 0);
+    if (trigger_register) return;
+  }
+}
+
+
+// program definitions
+void test_function() {
+  var pos = 0;
+  var user_reg_2 = getUserReg(2);
+  waitForSoftwareTrigger();
+  var init_pos_1 = pos;
+  repeat(12) {
+    pos = init_pos_1;
+    repeat(1000) { // stepping repeat
+      repeat(10) {
+        repeat(42) {
+          playWaveIndexed(test_concatenated_waveform_0, pos, 48, 2); // advance disabled do to parent repetition
+        }
+        repeat(98) {
+          playWave(test_shared_waveform_121f5c6e8822793b3836fb3098fa4591b91d4c205cc2d8afd01ee1bf6956e518, 0);
+        }
+      }
+      pos = pos + 48;
+    }
+    repeat(21) {
+      playWaveIndexed(test_concatenated_waveform_0, pos, 48, 2); // advance disabled do to parent repetition
+    }
+    pos = pos + 48;
+    repeat(23) {
+      playWaveIndexed(test_concatenated_waveform_0, pos, 48, 0); // advance disabled do to parent repetition
+    }
+    pos = pos + 48;
+    var idx_2;
+    for(idx_2 = 0; idx_2 < user_reg_2; idx_2 = idx_2 + 1) {
+      playWaveIndexed(test_concatenated_waveform_0, pos, 48, 0); // advance disabled do to parent repetition
+    }
+    pos = pos + 48;
+  }
+}
+
+// Declare and initialize global variables
+// Selected program index (0 -> None)
+var prog_sel = 0;
+
+// Value that gets written back to program selection register.
+// Used to signal that at least one program was played completely.
+var new_prog_sel = 0;
+
+// Is OR'ed to new_prog_sel.
+// Set to PLAYBACK_FINISHED_MASK if a program was played completely.
+var playback_finished = 0;
+
+
+// runtime block
+while (true) {
+  // read program selection value
+  prog_sel = getUserReg(PROG_SEL_REGISTER);
+  
+  // calculate value to write back to PROG_SEL_REGISTER
+  new_prog_sel = prog_sel | playback_finished;
+  if (!(prog_sel & NO_RESET_MASK)) new_prog_sel &= INVERTED_PROG_SEL_MASK;
+  setUserReg(PROG_SEL_REGISTER, new_prog_sel);
+  
+  // reset playback flag
+  playback_finished = 0;
+  
+  // only use part of prog sel that does not mean other things to select the program.
+  prog_sel &= PROG_SEL_MASK;
+  
+  switch (prog_sel) {
+    case 1:
+      test_function();
+      waitWave();
+      playback_finished = PLAYBACK_FINISHED_MASK;
+    default:
+      wait(IDLE_WAIT_CYCLES);
+  }
+}"""
+        self.assertEqual(expected_program, seqc_program)

--- a/tests/utils/numeric_tests.py
+++ b/tests/utils/numeric_tests.py
@@ -5,7 +5,7 @@ from fractions import Fraction
 from collections import deque
 from itertools import islice
 
-from qupulse.utils.numeric import approximate_rational, approximate_double
+from qupulse.utils.numeric import approximate_rational, approximate_double, smallest_factor_ge
 
 
 def stern_brocot_sequence() -> Iterator[int]:
@@ -109,3 +109,14 @@ class ApproximationTests(unittest.TestCase):
                                                    'which is not the expected {expected}'.format(x=x, err=err,
                                                                                                  result=result,
                                                                                                  expected=expected))
+
+
+class FactorizationTests(unittest.TestCase):
+    def test_smallest_factor_ge(self):
+        for brute_force in range(100):
+            self.assertEqual(smallest_factor_ge(15, 2), 3, brute_force)
+            self.assertEqual(smallest_factor_ge(15, 4), 5, brute_force)
+            self.assertEqual(smallest_factor_ge(45, 2), 3, brute_force)
+            self.assertEqual(smallest_factor_ge(45, 4), 5, brute_force)
+            self.assertEqual(smallest_factor_ge(45, 5), 5, brute_force)
+            self.assertEqual(smallest_factor_ge(36, 8), 9, brute_force)


### PR DESCRIPTION
 - New function `qupulse._program._loop.roll_constant_waveforms` that can transform long constant waveforms into repetitions of shorter waveforms.
 - The sample rate of HDAWG playbacks can now be dynamically reduced. Currently this can be enabled with the class attribute `qupulse._program.seqc.WaveformPlayback.ENABLE_DYNAMIC_RATE_REDUCTION`. #622

[Tests pass](https://github.com/qutech/qupulse/runs/4242052498)

Todo:
 - [x] newspiece for towncier