### PR TITLE
Travis CI maintanance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 env:
   - INSTALL_EXTRAS=[plotting,zurich-instruments,tektronix,tabor-instruments]
   - INSTALL_EXTRAS=[plotting,zurich-instruments,tektronix,tabor-instruments,Faster-fractions]
 
-#use container based infrastructure
-sudo: false
+# Ubuntu 20.04 LTS
+dist: focal
 
-#these directories are persistent
+# these directories are persistent
 cache: pip
 
 # install dependencies for gmpy2
@@ -18,22 +19,17 @@ addons:
   apt:
     update: true
 
-    sources:
-      # newer compiler for zhinst
-      - ubuntu-toolchain-r-test
-
     packages:
       - libgmp-dev
       - libmpfr-dev
       - libmpc-dev
 
 before_install:
-  - eval "CC=gcc-8 && GXX=g++-8"
   - pip install coverage coveralls
 install:
   - pip install .$INSTALL_EXTRAS
 script:
-  - "coverage run --source=qupulse --rcfile=coverage.ini setup.py test"
+  - "coverage run --source=qupulse --rcfile=coverage.ini -m pytest"
 after_success:
   - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ python:
   - 3.8
   - 3.9
 env:
-  - INSTALL_EXTRAS=[plotting,zurich-instruments,tektronix,tabor-instruments]
-  - INSTALL_EXTRAS=[plotting,zurich-instruments,tektronix,tabor-instruments,Faster-fractions]
+  - INSTALL_EXTRAS=[tests,plotting,zurich-instruments,tektronix,tabor-instruments]
+  - INSTALL_EXTRAS=[tests,plotting,zurich-instruments,tektronix,tabor-instruments,Faster-fractions]
 
 # Ubuntu 20.04 LTS
+os: linux
 dist: focal
 
 # these directories are persistent
@@ -29,7 +30,7 @@ before_install:
 install:
   - pip install .$INSTALL_EXTRAS
 script:
-  - "coverage run --source=qupulse --rcfile=coverage.ini -m pytest"
+  - "coverage run -m pytest"
 after_success:
   - coveralls
 

--- a/coverage.ini
+++ b/coverage.ini
@@ -1,6 +1,0 @@
-[run]
-branch = True
-omit = 
-    *main.py
-    *__init__.py
-    */qcmatlab/manager.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
 directory = "changes.d"

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,3 +74,8 @@ release = 0.5rc
 source-dir = ./doc/source
 build-dir = ./doc/build
 fresh-env = 1
+
+[coverage:run]
+branch = True
+omit =
+    *__init__.py

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -2,7 +2,7 @@ import unittest
 import contextlib
 import math
 import sys
-import distutils
+import distutils.version
 
 from typing import Union
 


### PR DESCRIPTION
 - Use Ubuntu 20.04 LTS and drop hard gcc-8 dependency.
 - Call pytest directly instead of the deprecated setup.py test.
 - Add python 3.9 to test suite