### PR TITLE
improve efficiency of TablePulseTemplate integral

### DIFF
--- a/qupulse/pulses/interpolation.py
+++ b/qupulse/pulses/interpolation.py
@@ -184,7 +184,7 @@ class JumpInterpolationStrategy(InterpolationStrategy):
         return self._integral_expression
 
     def evaluate_integral(self, t0, v0, t1, v1):
-        self._integral_method(t0, v0, t1, v1)
+        return self._integral_method(t0, v0, t1, v1)
 
     @property
     def expression(self) -> ExpressionScalar:

--- a/qupulse/pulses/table_pulse_template.py
+++ b/qupulse/pulses/table_pulse_template.py
@@ -75,12 +75,11 @@ class TableEntry(NamedTuple('TableEntry', [('t', ExpressionScalar),
             Scalar expression for the integral.
         """
         expr = 0
-        for first_entry, second_entry in pairwise(entry_sequence):
-            substitutions = {'t0': first_entry.t.sympified_expression,
-                             'v0': expression_extractor(first_entry.v),
-                             't1': second_entry.t.sympified_expression,
-                             'v1': expression_extractor(second_entry.v)}
-            expr += second_entry.interp.integral.sympified_expression.subs(substitutions, simultaneous=True)
+        time_value_pairs = [(entry.t.sympified_expression,expression_extractor(entry.v)) for entry in entry_sequence]
+        for idx, (first, second) in enumerate(pairwise(time_value_pairs)):
+            parameters = first[0], first[1], second[0], second[1]
+            second_entry = entry_sequence[idx+1]
+            expr += second_entry.interp.evaluate_integral(*parameters)
         return ExpressionScalar(expr)
 
     @classmethod

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -173,7 +173,10 @@ class DummyInterpolationStrategy(InterpolationStrategy):
     def expression(self) -> ExpressionScalar:
         raise NotImplementedError()
 
-
+    def evaluate_integral(self, t0, v0, t1, v1):
+        """ Evaluate integral using arguments v0, t0, v1, t1 """
+        raise
+        
 class DummyPulseTemplate(AtomicPulseTemplate):
 
     def __init__(self,


### PR DESCRIPTION
This PR improves the efficiency of calculation of integrals for the TablePulseTemplate. If there are no free variables in the TablePulseTemplate this calculation can be done even more efficiently, but this is not implemented in this PR.

- Lambdify integral expressions
- Use class variables for the expression and integral
- Reduce double evaluations in the TableEntry._sequence_integral

@terrorfisch 