### PR TITLE
Fix some unittest issues and deprecations

### DIFF
--- a/qupulse/_program/transformation.py
+++ b/qupulse/_program/transformation.py
@@ -149,7 +149,7 @@ class LinearTransformation(Transformation):
             return data_out
 
         try:
-            data_in = np.stack(data[in_channel] for in_channel in self._input_channels)
+            data_in = np.stack([data[in_channel] for in_channel in self._input_channels])
         except KeyError as error:
             raise KeyError('Invalid input channels', set(data.keys()), set(self._input_channels)) from error
 

--- a/qupulse/pulses/plotting.py
+++ b/qupulse/pulses/plotting.py
@@ -82,7 +82,8 @@ def render(program: Union[Loop],
         raise PlottingNotPossibleException(pulse=None,
                                            description='cannot render sequence with less than 2 data points')
     if not round(float(sample_count), 10).is_integer():
-        warnings.warn("Sample count {sample_count} is not an integer. Will be rounded (this changes the sample rate).".format(sample_count=sample_count))
+        warnings.warn(f"Sample count {sample_count} is not an integer. Will be rounded (this changes the sample rate).",
+                      stacklevel=2)
 
     times = np.linspace(float(start_time), float(end_time), num=int(sample_count), dtype=float)
     times[-1] = np.nextafter(times[-1], times[-2])
@@ -175,8 +176,8 @@ def plot(pulse: PulseTemplate,
         warnings.warn("Pulse to be plotted is empty!")
     elif times.size > maximum_points:
         # todo [2018-05-30]: since it results in an empty return value this should arguably be an exception, not just a warning
-        warnings.warn("Sampled pulse of size {wf_len} is lager than {max_points}".format(wf_len=times.size,
-                                                                                         max_points=maximum_points))
+        warnings.warn(f"Sampled pulse of size {times.size} is lager than {maximum_points}",
+                      stacklevel=2)
         return None
     else:
         duration = times[-1]

--- a/qupulse/utils/sympy.py
+++ b/qupulse/utils/sympy.py
@@ -434,7 +434,9 @@ def _parse_broadcast_shape(shape: Tuple[int], user: type) -> Optional[Tuple[int]
     except TypeError as err:
         warnings.warn(f"The shape passed to {user.__module__}.{user.__name__} is not convertible to a tuple of integers: {err}\n"
                       "Be aware that using a symbolic shape can lead to unexpected behaviour.",
-                      category=UnsupportedBroadcastArgumentWarning)
+                      category=UnsupportedBroadcastArgumentWarning,
+                      # probably sympy version dependent what is most useful here...
+                      stacklevel=7)
     return None
 
 
@@ -444,5 +446,7 @@ def _parse_broadcast_index(idx: int, user: type) -> Optional[int]:
     except TypeError as err:
         warnings.warn(f"The index passed to {user.__module__}.{user.__name__} is not convertible to an integer: {err}\n"
                       "Be aware that using a symbolic index can lead to unexpected behaviour.",
-                      category=UnsupportedBroadcastArgumentWarning)
+                      category=UnsupportedBroadcastArgumentWarning,
+                      # probably sympy version dependent what is most useful here...
+                      stacklevel=7)
     return None

--- a/tests/_program/seqc_tests.py
+++ b/tests/_program/seqc_tests.py
@@ -61,6 +61,10 @@ class BinaryWaveformTest(unittest.TestCase):
 
 
 def make_binary_waveform(waveform):
+    if zhinst is None:
+        # TODO: mock used function
+        raise unittest.SkipTest("zhinst not present")
+
     if waveform.duration == 0:
         data = np.asarray(3 * [1, 2, 3, 4, 5], dtype=np.uint16)
         return (BinaryWaveform(data),)

--- a/tests/backward_compatibility/tabor_backward_compatibility_tests.py
+++ b/tests/backward_compatibility/tabor_backward_compatibility_tests.py
@@ -6,6 +6,11 @@ import importlib.util
 import sys
 import warnings
 
+try:
+    import tabor_control
+except ImportError as err:
+    raise unittest.SkipTest("tabor_control not present") from err
+
 from tests.hardware.tabor_simulator_based_tests import TaborSimulatorManager
 from tests.hardware.dummy_devices import DummyDAC
 from tests.backward_compatibility.hardware_test_helper import LoadingAndSequencingHelper

--- a/tests/hardware/feature_awg/awg_new_driver_base_tests.py
+++ b/tests/hardware/feature_awg/awg_new_driver_base_tests.py
@@ -14,8 +14,8 @@ from qupulse.hardware.feature_awg.features import ChannelSynchronization, Progra
 # Example Features
 ########################################################################################################################
 
-class TestSynchronizeChannelsFeature(ChannelSynchronization):
-    def __init__(self, device: "TestAWGDevice"):
+class DummySynchronizeChannelsFeature(ChannelSynchronization):
+    def __init__(self, device: "DummyAWGDevice"):
         super().__init__()
         self._parent = device
 
@@ -24,13 +24,13 @@ class TestSynchronizeChannelsFeature(ChannelSynchronization):
         self._parent.synchronize_channels(group_size)
 
 
-class TestVolatileParameters(VolatileParameters):
+class DummyVolatileParameters(VolatileParameters):
     def set_volatile_parameters(self, program_name: str, parameters) -> None:
         raise NotImplementedError()
 
 
-class TestVoltageRangeFeature(VoltageRange):
-    def __init__(self, channel: "TestAWGChannel"):
+class DummyVoltageRangeFeature(VoltageRange):
+    def __init__(self, channel: "DummyAWGChannel"):
         super().__init__()
         self._parent = channel
 
@@ -65,7 +65,7 @@ class TestVoltageRangeFeature(VoltageRange):
         self._parent._ampl_offs_handling = ampl_offs_handling
 
 
-class TestProgramManagementFeature(ProgramManagement):
+class DummyProgramManagementFeature(ProgramManagement):
     def __init__(self, channel_tuple):
         super().__init__(channel_tuple=channel_tuple)
         self._programs = {}
@@ -113,15 +113,15 @@ class TestProgramManagementFeature(ProgramManagement):
 # Device & Channels
 ########################################################################################################################
 
-class TestAWGDevice(AWGDevice):
+class DummyAWGDevice(AWGDevice):
     def __init__(self, name: str):
         super().__init__(name)
 
         # Add feature to this object (self)
         # During this call, the function of the feature is dynamically added to this object
-        self.add_feature(TestSynchronizeChannelsFeature(self))
+        self.add_feature(DummySynchronizeChannelsFeature(self))
 
-        self._channels = [TestAWGChannel(i, self) for i in range(8)]  # 8 channels
+        self._channels = [DummyAWGChannel(i, self) for i in range(8)]  # 8 channels
         self._channel_tuples = []
 
         # Call the feature function, with the feature's signature
@@ -134,7 +134,7 @@ class TestAWGDevice(AWGDevice):
         self._channel_tuples.clear()
 
     @property
-    def channels(self) -> Collection["TestAWGChannel"]:
+    def channels(self) -> Collection["DummyAWGChannel"]:
         return self._channels
 
     @property
@@ -142,7 +142,7 @@ class TestAWGDevice(AWGDevice):
         return []
 
     @property
-    def channel_tuples(self) -> Collection["TestAWGChannelTuple"]:
+    def channel_tuples(self) -> Collection["DummyAWGChannelTuple"]:
         return self._channel_tuples
 
     def synchronize_channels(self, group_size: int) -> None:
@@ -159,19 +159,19 @@ class TestAWGDevice(AWGDevice):
 
         # Create channel tuples with its belonging channels and refer to their parent tuple
         for i, tmp_channel_tuple in enumerate(tmp_channel_tuples):
-            channel_tuple = TestAWGChannelTuple(i, self, tmp_channel_tuple)
+            channel_tuple = DummyAWGChannelTuple(i, self, tmp_channel_tuple)
             self._channel_tuples.append(channel_tuple)
             for channel in tmp_channel_tuple:
                 channel._set_channel_tuple(channel_tuple)
 
 
-class TestAWGChannelTuple(AWGChannelTuple):
-    def __init__(self, idn: int, device: TestAWGDevice, channels: Iterable["TestAWGChannel"]):
+class DummyAWGChannelTuple(AWGChannelTuple):
+    def __init__(self, idn: int, device: DummyAWGDevice, channels: Iterable["DummyAWGChannel"]):
         super().__init__(idn)
 
         # Add feature to this object (self)
         # During this call, the function of the feature is dynamically added to this object
-        self.add_feature(TestProgramManagementFeature(channel_tuple=self))
+        self.add_feature(DummyProgramManagementFeature(channel_tuple=self))
 
         self._device = device
         self._channels = tuple(channels)
@@ -190,11 +190,11 @@ class TestAWGChannelTuple(AWGChannelTuple):
         self._sample_rate = sample_rate
 
     @property
-    def device(self) -> TestAWGDevice:
+    def device(self) -> DummyAWGDevice:
         return self._device
 
     @property
-    def channels(self) -> Collection["TestAWGChannel"]:
+    def channels(self) -> Collection["DummyAWGChannel"]:
         return self._channels
 
     @property
@@ -202,13 +202,13 @@ class TestAWGChannelTuple(AWGChannelTuple):
         return []
 
 
-class TestAWGChannel(AWGChannel):
-    def __init__(self, idn: int, device: TestAWGDevice):
+class DummyAWGChannel(AWGChannel):
+    def __init__(self, idn: int, device: DummyAWGDevice):
         super().__init__(idn)
 
         # Add feature to this object (self)
         # During this call, all functions of the feature are dynamically added to this object
-        self.add_feature(TestVoltageRangeFeature(self))
+        self.add_feature(DummyVoltageRangeFeature(self))
 
         self._device = device
         self._channel_tuple = None
@@ -217,21 +217,21 @@ class TestAWGChannel(AWGChannel):
         self._ampl_offs_handling = AmplitudeOffsetHandling.IGNORE_OFFSET
 
     @property
-    def device(self) -> TestAWGDevice:
+    def device(self) -> DummyAWGDevice:
         return self._device
 
     @property
-    def channel_tuple(self) -> Optional[TestAWGChannelTuple]:
+    def channel_tuple(self) -> Optional[DummyAWGChannelTuple]:
         return self._channel_tuple
 
-    def _set_channel_tuple(self, channel_tuple: TestAWGChannelTuple) -> None:
+    def _set_channel_tuple(self, channel_tuple: DummyAWGChannelTuple) -> None:
         self._channel_tuple = channel_tuple
 
 
 class TestBaseClasses(unittest.TestCase):
     def setUp(self):
         self.device_name = "My device"
-        self.device = TestAWGDevice(self.device_name)
+        self.device = DummyAWGDevice(self.device_name)
 
     def test_device(self):
         self.assertEqual(self.device.name, self.device_name, "Invalid name for device")
@@ -274,10 +274,10 @@ class TestBaseClasses(unittest.TestCase):
             self.device[ChannelSynchronization].synchronize_channels(3)
 
         with self.assertRaises(KeyError):
-            self.device.add_feature(TestSynchronizeChannelsFeature(self.device))
+            self.device.add_feature(DummySynchronizeChannelsFeature(self.device))
 
         with self.assertRaises(TypeError):
-            self.device.add_feature(TestProgramManagementFeature())
+            self.device.add_feature(DummyProgramManagementFeature())
 
         with self.assertRaises(TypeError):
             self.device.features[ChannelSynchronization] = None

--- a/tests/hardware/feature_awg/channel_tuple_wrapper_tests.py
+++ b/tests/hardware/feature_awg/channel_tuple_wrapper_tests.py
@@ -2,14 +2,14 @@ from unittest import TestCase, mock
 
 from qupulse.hardware.feature_awg.features import ProgramManagement, VolatileParameters
 
-from tests.hardware.feature_awg.awg_new_driver_base_tests import TestAWGChannelTuple, TestAWGDevice, TestAWGChannel, TestVolatileParameters
+from tests.hardware.feature_awg.awg_new_driver_base_tests import DummyAWGChannelTuple, DummyAWGDevice, DummyAWGChannel, DummyVolatileParameters
 
 
 class ChannelTupleAdapterTest(TestCase):
     def setUp(self):
-        self.device = TestAWGDevice("device")
-        self.channels = [TestAWGChannel(0, self.device), TestAWGChannel(1, self.device)]
-        self.tuple = TestAWGChannelTuple(0, device=self.device, channels=self.channels)
+        self.device = DummyAWGDevice("device")
+        self.channels = [DummyAWGChannel(0, self.device), DummyAWGChannel(1, self.device)]
+        self.tuple = DummyAWGChannelTuple(0, device=self.device, channels=self.channels)
 
     def test_simple_properties(self):
         adapter = self.tuple.channel_tuple_adapter
@@ -60,7 +60,7 @@ class ChannelTupleAdapterTest(TestCase):
     def test_set_volatile_parameters(self):
         adapter = self.tuple.channel_tuple_adapter
 
-        self.tuple.add_feature(TestVolatileParameters(self.tuple))
+        self.tuple.add_feature(DummyVolatileParameters(self.tuple))
 
         with mock.patch.object(self.tuple[VolatileParameters], 'set_volatile_parameters') as set_volatile_parameters_mock:
             adapter.set_volatile_parameters('wurst', {'a': 5.})

--- a/tests/hardware/feature_awg/tabor_new_driver_simulator_based_tests.py
+++ b/tests/hardware/feature_awg/tabor_new_driver_simulator_based_tests.py
@@ -5,7 +5,10 @@ import platform
 import os
 from typing import List, Tuple, Optional, Any
 
-import tabor_control
+try:
+    import tabor_control
+except ImportError as err:
+    raise unittest.SkipTest("tabor_control not present") from err
 import numpy as np
 
 from qupulse._program.tabor import TableDescription, TableEntry

--- a/tests/hardware/feature_awg/tabor_new_driver_tests.py
+++ b/tests/hardware/feature_awg/tabor_new_driver_tests.py
@@ -1,5 +1,10 @@
 import unittest
 
+try:
+    import tabor_control
+except ImportError as err:
+    raise unittest.SkipTest("tabor_control not present") from err
+
 from qupulse.hardware.feature_awg.tabor import with_configuration_guard
 
 

--- a/tests/hardware/tabor_simulator_based_tests.py
+++ b/tests/hardware/tabor_simulator_based_tests.py
@@ -4,8 +4,12 @@ import time
 import platform
 import os
 
-import pyvisa.resources
-import tabor_control
+try:
+    import pyvisa.resources
+    import tabor_control
+except ImportError as err:
+    raise unittest.SkipTest("pyvisa and/or tabor_control not present") from err
+
 import numpy as np
 
 from qupulse.hardware.awgs.tabor import TaborAWGRepresentation, TaborChannelPair

--- a/tests/hardware/tabor_tests.py
+++ b/tests/hardware/tabor_tests.py
@@ -2,6 +2,11 @@ import unittest
 import itertools
 import numpy as np
 
+try:
+    import tabor_control
+except ImportError as err:
+    raise unittest.SkipTest("tabor_control not present") from err
+
 from qupulse.hardware.awgs.tabor import TaborException, TaborProgram, \
     TaborSegment, TaborSequencing, with_configuration_guard, PlottableProgram
 from qupulse._program._loop import Loop

--- a/tests/hardware/tektronix_tests.py
+++ b/tests/hardware/tektronix_tests.py
@@ -6,13 +6,10 @@ from unittest import mock
 import numpy as np
 try:
     import tek_awg
-except ImportError:
-    tek_awg = None
+except ImportError as err:
+    raise unittest.SkipTest("tek_awg not present") from err
 
-try:
-    import qupulse.hardware.awgs.tektronix as tektronix
-except ImportError:
-    tektronix = None
+import qupulse.hardware.awgs.tektronix as tektronix
 
 from qupulse.hardware.awgs.tektronix import TektronixAWG, TektronixProgram, parse_program, _make_binary_waveform,\
     voltage_to_uint16, WaveformEntry, WaveformStorage

--- a/tests/hardware/zihdawg_tests.py
+++ b/tests/hardware/zihdawg_tests.py
@@ -4,6 +4,11 @@ from collections import OrderedDict
 
 import numpy as np
 
+try:
+    import zhinst
+except ImportError as err:
+    raise unittest.SkipTest("zhinst not present") from err
+
 from qupulse.utils.types import TimeType
 from qupulse._program._loop import Loop
 from tests.pulses.sequencing_dummies import DummyWaveform

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -2,7 +2,11 @@ import unittest
 import contextlib
 import math
 import sys
-import distutils.version
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import StrictVersion as Version
 
 from typing import Union
 
@@ -486,7 +490,7 @@ class BroadcastTests(unittest.TestCase):
         self.assertEqual(expr_with_int, expr_with_int_other_order)
         self.assertEqual(expr_with_float, expr_with_int_other_order)
 
-    test_numeric_equal = unittest.expectedFailure(test_expression_equality) if distutils.version.StrictVersion(sympy.__version__) >= distutils.version.StrictVersion('1.5') else test_expression_equality
+    test_numeric_equal = unittest.expectedFailure(test_expression_equality) if Version(sympy.__version__) >= Version('1.5') else test_expression_equality
 
     def test_integral(self):
         symbolic = Broadcast(a*c, (3,))

--- a/tests/utils/sympy_tests.py
+++ b/tests/utils/sympy_tests.py
@@ -2,6 +2,7 @@ import unittest
 import contextlib
 import math
 import sys
+import warnings
 
 try:
     from packaging.version import Version
@@ -22,7 +23,8 @@ dummy_a = sympy.Dummy('a')
 
 from qupulse.utils.sympy import sympify as qc_sympify, substitute_with_eval, recursive_substitution, Len,\
     evaluate_lambdified, evaluate_compiled, get_most_simple_representation, get_variables, get_free_symbols,\
-    almost_equal, Broadcast, IndexedBasedFinder, IndexedBroadcast, evaluate_lamdified_exact_rational
+    almost_equal, Broadcast, IndexedBasedFinder, IndexedBroadcast, evaluate_lamdified_exact_rational,\
+    UnsupportedBroadcastArgumentWarning
 from qupulse.utils.types import TimeType
 
 
@@ -397,7 +399,8 @@ class AlmostEqualTests(unittest.TestCase):
 
 class BroadcastTests(unittest.TestCase):
     def test_symbolic_shape(self):
-        symbolic = Broadcast(a, (b,))
+        with self.assertWarns(UnsupportedBroadcastArgumentWarning):
+            symbolic = Broadcast(a, (b,))
         self.assertIs(symbolic.func, Broadcast)
         self.assertEqual(symbolic.args, (a, (b,)))
 
@@ -450,20 +453,23 @@ class BroadcastTests(unittest.TestCase):
         self.assertEqual(expected, Broadcast(expected, (4,)))
 
     def test_numeric_evaluation(self):
-        symbolic = Broadcast(a, (b,))
+        with self.assertWarns(UnsupportedBroadcastArgumentWarning):
+            # use c (and not b as above)
+            # here because sympy caches function call results and we want the warning everytime
+            symbolic = Broadcast(a, (c,))
 
-        arguments = {'a': (1, 2., 3), 'b': 3}
+        arguments = {'a': (1, 2., 3), 'c': 3}
         expected = np.asarray([1, 2., 3])
-        result, _ = evaluate_lambdified(symbolic, ['a', 'b'], arguments, None)
+        result, _ = evaluate_lambdified(symbolic, ['a', 'c'], arguments, None)
         np.testing.assert_array_equal(expected, result)
 
         with self.assertRaises(ValueError):
-            arguments = {'a': (1, 2., 3), 'b': 4}
-            evaluate_lambdified(symbolic, ['a', 'b'], arguments, None)
+            arguments = {'a': (1, 2., 3), 'c': 4}
+            evaluate_lambdified(symbolic, ['a', 'c'], arguments, None)
 
-        arguments = {'a': 1, 'b': 3}
+        arguments = {'a': 1, 'c': 3}
         expected = np.asarray([1, 1, 1])
-        result, _ = evaluate_lambdified(symbolic, ['a', 'b'], arguments, None)
+        result, _ = evaluate_lambdified(symbolic, ['a', 'c'], arguments, None)
         np.testing.assert_array_equal(expected, result)
 
     def test_sympification(self):


### PR DESCRIPTION
 - skip hardware related tests if requirements are not installed
 - Adhere to some new deprecations in numpz and distutils
 - Improve a few warnings by passing a more useful stacklevel