### PR TITLE
specialization to cast an expressionscalar to a float

### DIFF
--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -262,6 +262,12 @@ class ExpressionScalar(Expression):
 
         self._exact_rational_lambdified = None
 
+    def __float__(self):
+        if isinstance(self._original_expression, float):
+            return self._original_expression
+        else:
+            return super().__float__()
+
     @property
     def underlying_expression(self) -> sympy.Expr:
         return self._sympified_expression


### PR DESCRIPTION
The casting to float for an `ExpressionScalar` is an expensive operation. This PR specializes the `__float__` method to return the underlying expression in case the `ExpressionScalar` was constructed from a `float` .

@terrorfisch 