### PR TITLE
Use frozendict package

### DIFF
--- a/changes.d/639.removal
+++ b/changes.d/639.removal
@@ -1,0 +1,2 @@
+Add frozendict dependency to replace handwritten solution. Not having it installed will break in a future release
+when the old implementation is removed.

--- a/qupulse/_program/volatile.py
+++ b/qupulse/_program/volatile.py
@@ -5,12 +5,12 @@ import numbers
 
 from qupulse.parameter_scope import Scope, MappedScope, JointScope
 from qupulse.expressions import Expression, ExpressionScalar
-from qupulse.utils.types import FrozenDict
+from qupulse.utils.types import FrozenDict, FrozenMapping
 from qupulse.utils import is_integer
 
 
 VolatileProperty = NamedTuple('VolatileProperty', [('expression', Expression),
-                                                   ('dependencies', FrozenDict[str, Expression])])
+                                                   ('dependencies', FrozenMapping[str, Expression])])
 VolatileProperty.__doc__ = """Hashable representation of a volatile program property. It does not contain the concrete
 value. Using the dependencies attribute to calculate the value might yield unexpected results."""
 

--- a/qupulse/parameter_scope.py
+++ b/qupulse/parameter_scope.py
@@ -156,7 +156,7 @@ class MappedScope(Scope):
     def _collect_volatile_parameters(self) -> FrozenMapping[str, Expression]:
         inner_volatile = self._scope.get_volatile_parameters()
         if inner_volatile:
-            volatile = inner_volatile.to_dict()
+            volatile = dict(inner_volatile)
             for mapped_parameter, expression in self._mapping.items():
                 volatile_expr_dep = inner_volatile.keys() & expression.variables
                 if volatile_expr_dep:
@@ -174,7 +174,7 @@ class MappedScope(Scope):
         else:
             return inner_volatile
 
-    def get_volatile_parameters(self) -> AbstractSet[str]:
+    def get_volatile_parameters(self) -> FrozenMapping[str, Expression]:
         if self._volatile_parameters_cache is None:
             self._volatile_parameters_cache = self._collect_volatile_parameters()
         return self._volatile_parameters_cache

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -11,6 +11,11 @@ import operator
 import numpy
 import sympy
 
+try:
+    from frozendict import frozendict
+except ImportError:
+    frozendict = None
+
 import qupulse.utils.numeric as qupulse_numeric
 
 __all__ = ["MeasurementWindow", "ChannelID", "HashableNumpyArray", "TimeType", "time_from_float", "DocStringABCMeta",
@@ -505,7 +510,10 @@ class _FrozenDictByWrapping(FrozenMapping):
         return self._dict.copy()
 
 
-FrozenDict = _FrozenDictByWrapping
+if frozendict is None:
+    FrozenDict = _FrozenDictByWrapping
+else:
+    FrozenDict = frozendict
 
 
 class SequenceProxy(collections.abc.Sequence):

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -14,6 +14,8 @@ import sympy
 try:
     from frozendict import frozendict
 except ImportError:
+    warnings.warn("The frozendict package is not installed. We currently also ship a fallback frozendict which "
+                  "will be removed in a future release.", category=DeprecationWarning)
     frozendict = None
 
 import qupulse.utils.numeric as qupulse_numeric

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     sympy>=1.1.1
     numpy
     cached_property
+    frozendict
 test_suite = tests
 
 [options.extras_require]
@@ -46,7 +47,6 @@ zurich-instruments = zhinst
 Faster-fractions = gmpy2
 tektronix = tek_awg>=0.2.1
 autologging = autologging
-faster-frozendict = frozendict
 # sadly not open source for external legal reasons
 # commented out because pypi does not allow direct dependencies
 # atsaverage = atsaverage @ git+ssh://git@git.rwth-aachen.de/qutech/cpp-atsaverage.git@master#egg=atsaverage&subdirectory=python_source

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ zurich-instruments = zhinst
 Faster-fractions = gmpy2
 tektronix = tek_awg>=0.2.1
 autologging = autologging
+faster-frozendict = frozendict
 # sadly not open source for external legal reasons
 # commented out because pypi does not allow direct dependencies
 # atsaverage = atsaverage @ git+ssh://git@git.rwth-aachen.de/qutech/cpp-atsaverage.git@master#egg=atsaverage&subdirectory=python_source


### PR DESCRIPTION
Use frozendict package which includes a C extension instead of self-written python code. The `frozendict` creation is roughly 5 times faster on my machine.

We keep the hand rolled code around until the next release so we do not break code.

TODO:
 - [x] `DeprecationWarning` if `frozendict` is not installed
 - [x] Measure performance influence
 - [x] Add newspiece

Performance influence:
 -  on my machine 3% improvement of 
   ```
    ppt = PointPT([(0, 'i'), (1, 'i')], ('a',))
    fpt = ForLoopPT(ppt, 'i', 'n')
    fpt.create_program(parameters=dict(n=10000))```