### PR TITLE
Improve performance of expressionscalar operations

### DIFF
--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -321,8 +321,9 @@ class ExpressionScalar(Expression):
         return other._sympified_expression if isinstance(other, cls) else sympify(other)
 
     @classmethod
-    def _extract_sympified(cls, other: Union['ExpressionScalar', Number, sympy.Expr]) -> sympy.Expr:
-        return other._sympified_expression if isinstance(other, cls) else other
+    def _extract_sympified(cls, other: Union['ExpressionScalar', Number, sympy.Expr]) \
+                            -> Union['ExpressionScalar', Number, sympy.Expr]:
+        return getattr(other, '_sympified_expression', other)
 
     def __lt__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> Union[bool, None]:
         result = self._sympified_expression < self._extract_sympified(other)

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -344,7 +344,7 @@ class ExpressionScalar(Expression):
         """Enable comparisons with Numbers"""
         # sympy's __eq__ checks for structural equality to be consistent regarding __hash__ so we do that too
         # see https://github.com/sympy/sympy/issues/18054#issuecomment-566198899
-        return self._sympified_expression == self._extract_sympified(other)
+        return self._sympified_expression == self._sympify(other)
 
     def __hash__(self) -> int:
         return hash(self._sympified_expression)

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -350,28 +350,28 @@ class ExpressionScalar(Expression):
         return hash(self._sympified_expression)
 
     def __add__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__add__(self._sympify(other)))
+        return self.make(self._sympified_expression.__add__(self._extract_sympified(other)))
 
     def __radd__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
         return self.make(self._sympify(other).__radd__(self._sympified_expression))
 
     def __sub__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__sub__(self._sympify(other)))
+        return self.make(self._sympified_expression.__sub__(self._extract_sympified(other)))
 
     def __rsub__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__rsub__(self._sympify(other)))
+        return self.make(self._sympified_expression.__rsub__(self._extract_sympified(other)))
 
     def __mul__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__mul__(self._sympify(other)))
+        return self.make(self._sympified_expression.__mul__(self._extract_sympified(other)))
 
     def __rmul__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__rmul__(self._sympify(other)))
+        return self.make(self._sympified_expression.__rmul__(self._extract_sympified(other)))
 
     def __truediv__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__truediv__(self._sympify(other)))
+        return self.make(self._sympified_expression.__truediv__(self._extract_sympified(other)))
 
     def __rtruediv__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
-        return self.make(self._sympified_expression.__rtruediv__(self._sympify(other)))
+        return self.make(self._sympified_expression.__rtruediv__(self._extract_sympified(other)))
 
     def __neg__(self) -> 'ExpressionScalar':
         return self.make(self._sympified_expression.__neg__())

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -320,27 +320,31 @@ class ExpressionScalar(Expression):
     def _sympify(cls, other: Union['ExpressionScalar', Number, sympy.Expr]) -> sympy.Expr:
         return other._sympified_expression if isinstance(other, cls) else sympify(other)
 
+    @classmethod
+    def _extract_sympified(cls, other: Union['ExpressionScalar', Number, sympy.Expr]) -> sympy.Expr:
+        return other._sympified_expression if isinstance(other, cls) else other
+
     def __lt__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> Union[bool, None]:
-        result = self._sympified_expression < self._sympify(other)
+        result = self._sympified_expression < self._extract_sympified(other)
         return None if isinstance(result, sympy.Rel) else bool(result)
 
     def __gt__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> Union[bool, None]:
-        result = self._sympified_expression > self._sympify(other)
+        result = self._sympified_expression > self._extract_sympified(other)
         return None if isinstance(result, sympy.Rel) else bool(result)
 
     def __ge__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> Union[bool, None]:
-        result = self._sympified_expression >= self._sympify(other)
+        result = self._sympified_expression >= self._extract_sympified(other)
         return None if isinstance(result, sympy.Rel) else bool(result)
 
     def __le__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> Union[bool, None]:
-        result = self._sympified_expression <= self._sympify(other)
+        result = self._sympified_expression <= self._extract_sympified(other)
         return None if isinstance(result, sympy.Rel) else bool(result)
 
     def __eq__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> bool:
         """Enable comparisons with Numbers"""
         # sympy's __eq__ checks for structural equality to be consistent regarding __hash__ so we do that too
         # see https://github.com/sympy/sympy/issues/18054#issuecomment-566198899
-        return self._sympified_expression == self._sympify(other)
+        return self._sympified_expression == self._extract_sympified(other)
 
     def __hash__(self) -> int:
         return hash(self._sympified_expression)


### PR DESCRIPTION
For operators like `>` or `==` it is more efficient to let sympy do the conversion of non-sympy types. For types like `int` and `float` sympy can optimize.

@terrorfisch 
