### PR TITLE
Remove redundant linspace argument

### DIFF
--- a/qupulse/pulses/plotting.py
+++ b/qupulse/pulses/plotting.py
@@ -85,7 +85,7 @@ def render(program: Union[Loop],
         warnings.warn(f"Sample count {sample_count} is not an integer. Will be rounded (this changes the sample rate).",
                       stacklevel=2)
 
-    times = np.linspace(float(start_time), float(end_time), num=int(sample_count), dtype=float)
+    times = np.linspace(float(start_time), float(end_time), num=int(sample_count))
     times[-1] = np.nextafter(times[-1], times[-2])
 
     voltages = {ch: waveforms._ALLOCATION_FUNCTION(times, **waveforms._ALLOCATION_FUNCTION_KWARGS)


### PR DESCRIPTION
This improves performance together with https://github.com/numpy/numpy/pull/21832

The argument is not required, since `start` and `stop` are cast to float.

@terrorfisch 