### PR TITLE
Make FunctionPT.build_waveform use from_expression

### DIFF
--- a/qupulse/pulses/function_pulse_template.py
+++ b/qupulse/pulses/function_pulse_template.py
@@ -105,7 +105,7 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
         expression = self.__expression.evaluate_symbolic(substitutions=parameters)
         duration = self.__duration_expression.evaluate_with_exact_rationals(parameters)
 
-        return FunctionWaveform(expression=expression,
+        return FunctionWaveform.from_expression(expression=expression,
                                 duration=duration,
                                 channel=channel_mapping[self.__channel])
 


### PR DESCRIPTION
FunctionPT.build_waveform should return ConstantWaveform now if the expressions evaluates to a constant value. This was an oversight in earlier changes.

@peendebak Should fix your warning problem and result in more performant programs.