### PR TITLE
Prevent pandas import at startup

### DIFF
--- a/qupulse/_program/transformation.py
+++ b/qupulse/_program/transformation.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Set, Tuple, Sequence, AbstractSet, Union
+from typing import Any, Mapping, Set, Tuple, Sequence, AbstractSet, Union, TYPE_CHECKING
 from abc import abstractmethod
 from numbers import Real
 
@@ -255,9 +255,13 @@ class ScalingTransformation(Transformation):
 
 
 try:
-    import pandas
+    if TYPE_CHECKING:
+        import pandas
+        PandasDataFrameType = pandas.DataFrame
+    else:
+        PandasDataFrameType = Any
 
-    def linear_transformation_from_pandas(transformation: pandas.DataFrame) -> LinearTransformation:
+    def linear_transformation_from_pandas(transformation: PandasDataFrameType) -> LinearTransformation:
         """ Creates a LinearTransformation object out of a pandas data frame.
 
         Args:


### PR DESCRIPTION
This PR reduces the qupulse import time by almost a second by skipping the import of `pandas`.
The code could be simplified if we skip the type annotation for the `linear_transformation_from_pandas` method.

@terrorfisch 
