### PR TITLE
Cleanup ConstantPT and extend capabilities

### DIFF
--- a/qupulse/pulses/constant_pulse_template.py
+++ b/qupulse/pulses/constant_pulse_template.py
@@ -8,41 +8,45 @@ Classes:
 
 import logging
 import numbers
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Union, Mapping, AbstractSet
 
 from qupulse._program.waveforms import ConstantWaveform
-from qupulse.expressions import ExpressionScalar
-from qupulse.parameter_scope import Scope
+from qupulse.utils.types import TimeType, ChannelID
+from qupulse.utils import cached_property
+from qupulse.expressions import ExpressionScalar, ExpressionLike
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
-from qupulse.pulses.parameters import ParameterNotProvidedException
-from qupulse.pulses.pulse_template import (AtomicPulseTemplate, ChannelID,
-                                           Loop, MeasurementDeclaration,
-                                           PulseTemplate, Transformation,
-                                           TransformingWaveform)
+from qupulse.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration
+from qupulse.serialization import PulseRegistryType
 
 __all__ = ["ConstantPulseTemplate"]
 
 
 class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
-
-    def __init__(self, duration: float, amplitude_dict: Dict[str, Any], identifier: Optional[str] = None,
-                 name: Optional[str] = None, measurements: Optional[List[MeasurementDeclaration]] = [], **kwargs: Any) -> None:
-        """ A qupulse waveform representing a multi-channel pulse with constant values
+    def __init__(self, duration: ExpressionLike, amplitude_dict: Dict[ChannelID, ExpressionLike],
+                 identifier: Optional[str] = None,
+                 name: Optional[str] = None,
+                 measurements: Optional[List[MeasurementDeclaration]] = None,
+                 registry: PulseRegistryType=None) -> None:
+        """An atomic pulse template qupulse representing a multi-channel pulse with constant values.
         
         Args:
             duration: Duration of the template
             amplitude_dict: Dictionary with values for the channels
-            name: Name for the template
-        
+            name: Name for the template. Not used by qupulse
         """
-        super().__init__(identifier=identifier, measurements=measurements, **kwargs)
+        super().__init__(identifier=identifier, measurements=measurements)
 
-        self._duration = ExpressionScalar(duration)
-        self._amplitude_dict = amplitude_dict
+        # we special case numeric values in this PulseTemplate for performance reasons
+        self._duration = duration if isinstance(duration, (float, int, TimeType)) else ExpressionScalar(duration)
+        self._amplitude_dict: Mapping[ChannelID, Union[float, ExpressionScalar]] = {
+            channel: value if isinstance(value, (float, int)) else ExpressionScalar(value)
+            for channel, value in amplitude_dict.items()}
 
         if name is None:
             name = 'constant_pulse'
         self._name = name
+
+        self._register(registry)
 
     def _as_expression(self):
         return self._amplitude_dict
@@ -50,12 +54,16 @@ class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
     def __str__(self) -> str:
         return '<{} at %x{}: {}>'.format(self.__class__.__name__, '%x' % id(self), self._name)
 
-    def build_sequence(self) -> None:
-        return
-
-    def get_serialization_data(self) -> Any:
+    def get_serialization_data(self, serializer=None) -> Any:
+        if serializer is not None:
+            raise NotImplementedError("ConstantPulseTemplate does not implement legacy serialization.")
         data = super().get_serialization_data()
-        data.update({'name': self._name, 'duration': self._duration, '#amplitudes': self._amplitude_dict})
+        data.update({
+            'name': self._name,
+            'duration': self._duration,
+            'amplitude_dict': self._amplitude_dict,
+            'measurements': self.measurement_declarations
+        })
         return data
 
     @property
@@ -63,56 +71,30 @@ class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
         """Returns an expression giving the integral over the pulse."""
         return {c: self.duration * self._amplitude_dict[c] for c in self._amplitude_dict}
 
-    @property
-    def parameter_names(self) -> Set[str]:
+    @cached_property
+    def parameter_names(self) -> AbstractSet[str]:
         """The set of names of parameters required to instantiate this PulseTemplate."""
-        return set()
+        parameters = []
+        for amplitude in self._amplitude_dict.values():
+            if hasattr(amplitude, 'variables'):
+                parameters.extend(amplitude.variables)
+        if hasattr(self._duration, 'variables'):
+            parameters.extend(self._duration.variables)
+        parameters.extend(self.measurement_parameters)
+        return frozenset(parameters)
 
-    @property
-    def is_interruptable(self) -> bool:
-        """Return true, if this PulseTemplate contains points at which it can halt if interrupted.
-        """
-        return False
-
-    @property
+    @cached_property
     def duration(self) -> ExpressionScalar:
         """An expression for the duration of this PulseTemplate."""
-        return (self._duration)
+        if isinstance(self._duration, ExpressionScalar):
+            return self._duration
+        else:
+            return ExpressionScalar(self._duration)
 
     @property
-    def defined_channels(self) -> Set['ChannelID']:
+    def defined_channels(self) -> AbstractSet['ChannelID']:
         """Returns the number of hardware output channels this PulseTemplate defines."""
-        return set(self._amplitude_dict.keys())
-
-    def requires_stop(self) -> bool:  # from SequencingElement
-        return False
-
-    def _internal_create_program(self, *,
-                                 scope: Scope,
-                                 measurement_mapping: Dict[str, Optional[str]],
-                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
-                                 global_transformation: Optional[Transformation],
-                                 to_single_waveform: Set[Union[str, PulseTemplate]],
-                                 parent_loop: Loop) -> None:
-        """ removed from qupulse docstring """
-        try:
-            parameters = {parameter_name: scope[parameter_name].get_value()
-                          for parameter_name in self.parameter_names}
-        except KeyError as e:
-            raise ParameterNotProvidedException(str(e)) from e
-
-        waveform = self.build_waveform(parameters=parameters,
-                                       channel_mapping=channel_mapping)
-        if waveform:
-            measurements: List[Any] = []
-            measurements = self.get_measurement_windows(parameters=parameters,
-                                                        measurement_mapping=measurement_mapping)
-
-            if global_transformation:
-                waveform = TransformingWaveform.from_transformation(waveform, global_transformation)
-
-            parent_loop.add_measurements(measurements=measurements)
-            parent_loop.append_child(waveform=waveform)
+        return self._amplitude_dict.keys()
 
     def build_waveform(self,
                        parameters: Dict[str, numbers.Real],
@@ -121,13 +103,20 @@ class ConstantPulseTemplate(AtomicPulseTemplate):  # type: ignore
         logging.debug(f'build_waveform of ConstantPulse: channel_mapping {channel_mapping}, '
                       f'defined_channels {self.defined_channels}')
 
-        constant_values = {}
-        for channel, value in self._amplitude_dict.items():
-            mapped_channel = channel_mapping[channel]
-            if mapped_channel is not None:
-                constant_values[mapped_channel] = value
+        # we very freely use duck-typing here to speed up cases where duration and amplitude values are already numeric
+        duration = self._duration
+        if hasattr(duration, 'evaluate_in_scope'):
+            duration = duration.evaluate_in_scope(parameters)
 
-        if constant_values:
-            return ConstantWaveform.from_mapping(self.duration, constant_values)
-        else:
-            return None
+        if duration > 0:
+            constant_values = {}
+            for channel, value in self._amplitude_dict.items():
+                mapped_channel = channel_mapping[channel]
+                if mapped_channel is not None:
+                    if hasattr(value, 'evaluate_in_scope'):
+                        value = value.evaluate_in_scope(parameters)
+                    constant_values[mapped_channel] = value
+
+            if constant_values:
+                return ConstantWaveform.from_mapping(duration, constant_values)
+        return None

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -9,8 +9,9 @@ from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate
 from qupulse._program._loop import make_compatible
 from qupulse._program.waveforms import ConstantWaveform
 
-from qupulse.pulses.constant_pulse_template import ConstantPulseTemplate
+from qupulse.pulses.constant_pulse_template import ConstantPulseTemplate, ExpressionScalar, TimeType
 
+from tests.serialization_tests import SerializableTests
 
 class TestConstantPulseTemplate(unittest.TestCase):
 
@@ -87,6 +88,23 @@ class TestConstantPulseTemplate(unittest.TestCase):
         plot(p)
         self.assertEqual(p.defined_channels, {'C2'})
 
+    def test_expressions(self):
+        cpt = ConstantPulseTemplate('duration', {'A': 5.4, 'B': 'amplitude_b'})
+        self.assertEqual({'duration', 'amplitude_b'}, cpt.parameter_names)
+        self.assertEqual(ExpressionScalar('duration'), cpt.duration)
+
+        self.assertIsNone(cpt.build_waveform({'duration': 0., 'amplitude_b': 1.}, {'A': 'A', 'B': 'B'}))
+        self.assertIsNone(cpt.build_waveform({'duration': 1., 'amplitude_b': 1.}, {'A': None, 'B': None}))
+
+        wf1 = ConstantWaveform(duration=TimeType.from_float(1.4), channel='C', amplitude=1.6)
+        wf2 = ConstantWaveform(duration=TimeType.from_float(1.5), channel='A', amplitude=5.4)
+        self.assertEqual(wf1, cpt.build_waveform({'duration': 1.4, 'amplitude_b': 1.6}, {'A': None, 'B': 'C'}))
+        self.assertEqual(wf2, cpt.build_waveform({'duration': 1.5, 'amplitude_b': None}, {'A': 'A', 'B': None}))
+
+        wf3 = ConstantWaveform.from_mapping(duration=TimeType.from_float(1.6), constant_values={'C': 5.4, 'B': -.3})
+        self.assertEqual(wf3, cpt.build_waveform({'duration': 1.6, 'amplitude_b': -.3}, {'A': 'C', 'B': 'B'}))
+
+
     def test_build_waveform(self):
         tpt = ConstantPulseTemplate(200, {'C1': 2, 'C2': 3})
 
@@ -115,3 +133,25 @@ class TestConstantPulseTemplate(unittest.TestCase):
         )
 
         self.assertIsNone(tpt.build_waveform({}, {'C1': None, 'C2': None}))
+
+
+class ConstantPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
+    @property
+    def class_to_test(self):
+        return ConstantPulseTemplate
+
+    def make_kwargs(self):
+        return {
+            'name': 'yoho',
+            'duration': 'dur',
+            'amplitude_dict': {'int': 1, 'float': -3.4, 'expr': 'x + y'},
+            'measurements': [('m', 1, 1), ('foo', 'z', 'o')],
+        }
+
+    def assert_equal_instance_except_id(self, lhs: ConstantPulseTemplate, rhs: ConstantPulseTemplate):
+        self.assertIsInstance(lhs, ConstantPulseTemplate)
+        self.assertIsInstance(rhs, ConstantPulseTemplate)
+        self.assertEqual(lhs._name, rhs._name)
+        self.assertEqual(lhs.measurement_declarations, rhs.measurement_declarations)
+        self.assertEqual(lhs._amplitude_dict, rhs._amplitude_dict)
+        self.assertEqual(lhs.duration, rhs.duration)


### PR DESCRIPTION
Add explicit expression support to ConstantPulseTemplate with a fast path for float. Add extensive testing, serialize measurement windows and honor the pulse registry.

@eendebakpt This should not lead to a measurable slow down. Please check if you have concerns with this