### PR TITLE
Remove override of _parse_evaluate_numeric_result

### DIFF
--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -404,15 +404,15 @@ class ExpressionScalar(Expression):
     def is_nan(self) -> bool:
         return sympy.sympify('nan') == self._sympified_expression
 
-    def _parse_evaluate_numeric_result(self,
-                                       result: Union[Number, numpy.ndarray],
-                                       call_arguments: Any) -> Number:
-        """Overwrite super class method because we do not want to return a scalar numpy.ndarray"""
-        parsed = super()._parse_evaluate_numeric_result(result, call_arguments)
-        if isinstance(parsed, numpy.ndarray):
-            return parsed[()]
-        else:
-            return parsed
+    # def _parse_evaluate_numeric_result(self,
+    #                                    result: Union[Number, numpy.ndarray],
+    #                                    call_arguments: Any) -> Number:
+    #     """Overwrite super class method because we do not want to return a scalar numpy.ndarray"""
+    #     parsed = super()._parse_evaluate_numeric_result(result, call_arguments)
+    #     if isinstance(parsed, numpy.ndarray):
+    #         return parsed[()]
+    #     else:
+    #         return parsed
 
     def evaluate_with_exact_rationals(self, scope: Mapping) -> Number:
         parsed_kwargs = self._parse_evaluate_numeric_arguments(scope)

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -404,16 +404,6 @@ class ExpressionScalar(Expression):
     def is_nan(self) -> bool:
         return sympy.sympify('nan') == self._sympified_expression
 
-    # def _parse_evaluate_numeric_result(self,
-    #                                    result: Union[Number, numpy.ndarray],
-    #                                    call_arguments: Any) -> Number:
-    #     """Overwrite super class method because we do not want to return a scalar numpy.ndarray"""
-    #     parsed = super()._parse_evaluate_numeric_result(result, call_arguments)
-    #     if isinstance(parsed, numpy.ndarray):
-    #         return parsed[()]
-    #     else:
-    #         return parsed
-
     def evaluate_with_exact_rationals(self, scope: Mapping) -> Number:
         parsed_kwargs = self._parse_evaluate_numeric_arguments(scope)
         result, self._exact_rational_lambdified = evaluate_lamdified_exact_rational(self.sympified_expression,

--- a/qupulse/expressions.py
+++ b/qupulse/expressions.py
@@ -63,16 +63,18 @@ class Expression(AnonymousSerializable, metaclass=_ExpressionMeta):
         if isinstance(result, tuple):
             result = numpy.array(result)
         if isinstance(result, numpy.ndarray):
-            if issubclass(result.dtype.type, allowed_types):
-                return result
-            else:
+            if not issubclass(result.dtype.type, allowed_types):
                 obj_types = set(map(type, result.flat))
                 if all(issubclass(obj_type, sympy.Integer) for obj_type in obj_types):
-                    return result.astype(numpy.int64)
-                if all(issubclass(obj_type, (sympy.Integer, sympy.Float)) for obj_type in obj_types):
-                    return result.astype(float)
+                    result = result.astype(numpy.int64)
+                elif all(issubclass(obj_type, (sympy.Integer, sympy.Float)) for obj_type in obj_types):
+                    result = result.astype(float)
                 else:
                     raise NonNumericEvaluation(self, result, call_arguments)
+            if result.shape==():
+                # a scalar numpy array. cast to a pure scalar
+                result = result[()]
+            return result
         elif isinstance(result, allowed_types):
             return result
         elif isinstance(result, sympy.Float):


### PR DESCRIPTION
@terrorfisch With the new rust backend performance has improved, but off course there are new bottlenecks.

This PR removes a small bottleneck. I could not find a reason for the additional transformation in the current codebase, but perhaps you know why it was added.