### PR TITLE
Add support for time dependent expressions in transformations.

### DIFF
--- a/changes.d/709.feature
+++ b/changes.d/709.feature
@@ -1,0 +1,3 @@
+Add support for time dependent expressions for arithmetics with atomic pulse templates i.e. ParallelChannelPT and
+ArithmeticPT support time dependent expressions if used with atomic pulse templates.
+Rename `ParallelConstantChannelPT` to `ParallelChannelPT` to reflect this change.

--- a/qupulse/_program/transformation.py
+++ b/qupulse/_program/transformation.py
@@ -392,7 +392,7 @@ def _get_constant_output_channels(expressions: Mapping[ChannelID, _TrafoValue],
                                   constant_input_channels: AbstractSet[ChannelID]) -> AbstractSet[ChannelID]:
     return {ch
             for ch in constant_input_channels
-            if hasattr(expressions[ch], 'variables')}
+            if not hasattr(expressions.get(ch, None), 'variables')}
 
 def _are_valid_transformation_expressions(expressions: Mapping[ChannelID, _TrafoValue]) -> bool:
     return all(expr.variables == ('t',)

--- a/qupulse/pulses/__init__.py
+++ b/qupulse/pulses/__init__.py
@@ -7,7 +7,8 @@ from qupulse.pulses.abstract_pulse_template import AbstractPulseTemplate as Abst
 from qupulse.pulses.function_pulse_template import FunctionPulseTemplate as FunctionPT
 from qupulse.pulses.loop_pulse_template import ForLoopPulseTemplate as ForLoopPT
 from qupulse.pulses.multi_channel_pulse_template import AtomicMultiChannelPulseTemplate as AtomicMultiChannelPT,\
-    ParallelConstantChannelPulseTemplate as ParallelConstantChannelPT
+    ParallelConstantChannelPulseTemplate as ParallelConstantChannelPT,\
+    ParallelChannelPulseTemplate as ParallelChannelPT
 from qupulse.pulses.mapping_pulse_template import MappingPulseTemplate as MappingPT
 from qupulse.pulses.repetition_pulse_template import RepetitionPulseTemplate as RepetitionPT
 from qupulse.pulses.sequence_pulse_template import SequencePulseTemplate as SequencePT
@@ -30,5 +31,4 @@ del warnings
 
 __all__ = ["FunctionPT", "ForLoopPT", "AtomicMultiChannelPT", "MappingPT", "RepetitionPT", "SequencePT", "TablePT",
            "PointPT", "ConstantPT", "AbstractPT", "ParallelConstantChannelPT", "ArithmeticPT", "ArithmeticAtomicPT",
-           "TimeReversalPT"]
-
+           "TimeReversalPT", "ParallelChannelPT"]

--- a/qupulse/pulses/arithmetic_pulse_template.py
+++ b/qupulse/pulses/arithmetic_pulse_template.py
@@ -298,7 +298,7 @@ class ArithmeticPulseTemplate(PulseTemplate):
                     if channel_mapping[channel]}
 
         else:
-            return {channel_mapping[channel]: value.evaluate_in_scope(parameters)
+            return {channel_mapping[channel]: value.evaluate_symbolic(parameters) if 't' in value.variables else value.evaluate_in_scope(parameters)
                     for channel, value in self._scalar.items()
                     if channel_mapping[channel]}
 
@@ -479,9 +479,11 @@ class ArithmeticPulseTemplate(PulseTemplate):
     @cached_property
     def _scalar_operand_parameters(self) -> FrozenSet[str]:
         if isinstance(self._scalar, dict):
-            return frozenset(*(value.variables for value in self._scalar.values()))
+            return frozenset(variable
+                             for value in self._scalar.values()
+                             for variable in value.variables) - {'t'}
         else:
-            return frozenset(self._scalar.variables)
+            return frozenset(self._scalar.variables) - {'t'}
 
     @property
     def parameter_names(self) -> Set[str]:

--- a/qupulse/pulses/mapping_pulse_template.py
+++ b/qupulse/pulses/mapping_pulse_template.py
@@ -112,7 +112,7 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
                                for k, v in template.channel_mapping.items()}
             template = template.template
 
-        self.__template = template
+        self.__template: PulseTemplate = template
         self.__parameter_mapping = FrozenDict(parameter_mapping)
         self.__external_parameters = set(itertools.chain(*(expr.variables for expr in self.__parameter_mapping.values())))
         self.__external_parameters |= self.constrained_parameters
@@ -229,6 +229,9 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
             data['parameter_constraints'] = [str(c) for c in self.parameter_constraints]
 
         return data
+
+    def _is_atomic(self):
+        return self.__template._is_atomic()
 
     @classmethod
     def deserialize(cls,

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -4,7 +4,7 @@ AtomicPulseTemplates into a single template spanning several channels.
 Classes:
     - MultiChannelPulseTemplate: A pulse template defined for several channels by combining pulse
         templates
-    - MultiChannelWaveform: A waveform defined for several channels by combining waveforms
+    - ParallelChannelPulseTemplate: A pulse template to add channels to an existing pulse template.
 """
 
 from typing import Dict, List, Optional, Any, AbstractSet, Union, Set, Sequence, Mapping

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -216,6 +216,16 @@ class ParallelChannelPulseTemplate(PulseTemplate):
                  overwritten_channels: Mapping[ChannelID, Union[ExpressionScalar, Sympifyable]], *,
                  identifier: Optional[str]=None,
                  registry: Optional[PulseRegistryType] = None):
+        """Pulse template to add new or overwrite existing channels of a contained pulse template. The channel values
+        may be time dependent if the contained pulse template is atomic.
+
+        Args:
+            template: Inner pulse template where all channels that are not overwritten will stay the same.
+            overwritten_channels: Mapping of channels to values that this channel will have. This can overwrite existing
+            channels or add new ones. May be time dependent if template is atomic.
+            identifier: Name of the pulse template for serialization
+            registry: Pulse template gets registered here if not None.
+        """
         super().__init__(identifier=identifier)
 
         self._template = template

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -283,7 +283,7 @@ class ParallelChannelPulseTemplate(PulseTemplate):
 
     @property
     def transformation_parameters(self) -> AbstractSet[str]:
-        return set().union(*(value.variables for value in self.overwritten_channels.values()))
+        return set().union(*(value.variables for value in self.overwritten_channels.values())) - {'t'}
 
     @property
     def parameter_names(self):

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -29,7 +29,6 @@ __all__ = ["AtomicMultiChannelPulseTemplate", "ParallelConstantChannelPulseTempl
 
 
 class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
-    """Combines multiple PulseTemplates that are defined on different channels into an AtomicPulseTemplate."""
     def __init__(self,
                  *subtemplates: Union[AtomicPulseTemplate, MappingTuple, MappingPulseTemplate],
                  identifier: Optional[str] = None,
@@ -37,9 +36,11 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
                  measurements: Optional[List[MeasurementDeclaration]] = None,
                  registry: PulseRegistryType = None,
                  duration: Optional[ExpressionLike] = None) -> None:
-        """Parallels multiple AtomicPulseTemplates of the same duration. If the duration keyword argument is given
-        it is enforced that the instantiated pulse template has this duration. If duration is None the duration of the
-        PT is the duration of the first subtemplate. There are probably changes to this behaviour in the future.
+        """Combines multiple AtomicPulseTemplates of the same duration that are defined on different channels into an
+        AtomicPulseTemplate.
+        If the duration keyword argument is given it is enforced that the instantiated pulse template has this duration.
+        If duration is None the duration of the PT is the duration of the first subtemplate.
+        There are probably changes to this behaviour in the future.
 
         Args:
             *subtemplates: Positional arguments are subtemplates to combine.

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -18,7 +18,7 @@ from qupulse.utils import isclose
 from qupulse.utils.sympy import almost_equal, Sympifyable
 from qupulse.utils.types import ChannelID, TimeType
 from qupulse._program.waveforms import MultiChannelWaveform, Waveform, TransformingWaveform
-from qupulse._program.transformation import ParallelConstantChannelTransformation, Transformation, chain_transformations
+from qupulse._program.transformation import ParallelConstantTransformation, Transformation, chain_transformations
 from qupulse.pulses.pulse_template import PulseTemplate, AtomicPulseTemplate
 from qupulse.pulses.mapping_pulse_template import MappingPulseTemplate, MappingTuple
 from qupulse.pulses.parameters import Parameter, ParameterConstrainer
@@ -245,7 +245,7 @@ class ParallelConstantChannelPulseTemplate(PulseTemplate):
                                  channel_mapping: Dict[ChannelID, Optional[ChannelID]],
                                  **kwargs):
         overwritten_channels = self._get_overwritten_channels_values(parameters=scope, channel_mapping=channel_mapping)
-        transformation = ParallelConstantChannelTransformation(overwritten_channels)
+        transformation = ParallelConstantTransformation(overwritten_channels)
 
         if global_transformation is not None:
             transformation = chain_transformations(global_transformation, transformation)
@@ -262,7 +262,7 @@ class ParallelConstantChannelPulseTemplate(PulseTemplate):
         if inner_waveform:
             overwritten_channels = self._get_overwritten_channels_values(parameters=parameters,
                                                                          channel_mapping=channel_mapping)
-            transformation = ParallelConstantChannelTransformation(overwritten_channels)
+            transformation = ParallelConstantTransformation(overwritten_channels)
             return TransformingWaveform.from_transformation(inner_waveform, transformation)
 
     @property

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -18,7 +18,7 @@ from qupulse.utils import isclose
 from qupulse.utils.sympy import almost_equal, Sympifyable
 from qupulse.utils.types import ChannelID, TimeType
 from qupulse._program.waveforms import MultiChannelWaveform, Waveform, TransformingWaveform
-from qupulse._program.transformation import ParallelConstantTransformation, Transformation, chain_transformations
+from qupulse._program.transformation import ParallelChannelTransformation, Transformation, chain_transformations
 from qupulse.pulses.pulse_template import PulseTemplate, AtomicPulseTemplate
 from qupulse.pulses.mapping_pulse_template import MappingPulseTemplate, MappingTuple
 from qupulse.pulses.parameters import Parameter, ParameterConstrainer
@@ -245,7 +245,7 @@ class ParallelConstantChannelPulseTemplate(PulseTemplate):
                                  channel_mapping: Dict[ChannelID, Optional[ChannelID]],
                                  **kwargs):
         overwritten_channels = self._get_overwritten_channels_values(parameters=scope, channel_mapping=channel_mapping)
-        transformation = ParallelConstantTransformation(overwritten_channels)
+        transformation = ParallelChannelTransformation(overwritten_channels)
 
         if global_transformation is not None:
             transformation = chain_transformations(global_transformation, transformation)
@@ -262,7 +262,7 @@ class ParallelConstantChannelPulseTemplate(PulseTemplate):
         if inner_waveform:
             overwritten_channels = self._get_overwritten_channels_values(parameters=parameters,
                                                                          channel_mapping=channel_mapping)
-            transformation = ParallelConstantTransformation(overwritten_channels)
+            transformation = ParallelChannelTransformation(overwritten_channels)
             return TransformingWaveform.from_transformation(inner_waveform, transformation)
 
     @property

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -6,6 +6,7 @@ Classes:
     - AtomicPulseTemplate: PulseTemplate that does imply any control flow disruptions and can be
         directly translated into a waveform.
 """
+import warnings
 from abc import abstractmethod
 from typing import Dict, Tuple, Set, Optional, Union, List, Callable, Any, Generic, TypeVar, Mapping
 import itertools
@@ -78,6 +79,10 @@ class PulseTemplate(Serializable):
     def num_channels(self) -> int:
         """The number of channels this PulseTemplate defines"""
         return len(self.defined_channels)
+
+    def _is_atomic(self) -> bool:
+        """This is (currently a private) a check if this pulse template always is translated into a single waveform."""
+        return False
 
     def __matmul__(self, other: Union['PulseTemplate', MappingTuple]) -> 'SequencePulseTemplate':
         """This method enables using the @-operator (intended for matrix multiplication) for
@@ -319,6 +324,10 @@ class AtomicPulseTemplate(PulseTemplate, MeasurementDefiner):
 
     @property
     def atomicity(self) -> bool:
+        warnings.warn("Deprecated since neither maintained nor properly designed.", category=DeprecationWarning)
+        return True
+
+    def _is_atomic(self) -> bool:
         return True
 
     measurement_names = MeasurementDefiner.measurement_names

--- a/qupulse/pulses/time_reversal_pulse_template.py
+++ b/qupulse/pulses/time_reversal_pulse_template.py
@@ -58,3 +58,6 @@ class TimeReversalPulseTemplate(PulseTemplate):
             **super().get_serialization_data(),
             'inner': self._inner
         }
+
+    def _is_atomic(self) -> bool:
+        return self._inner._is_atomic()

--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -21,7 +21,7 @@ except ImportError:
 import qupulse.utils.numeric as qupulse_numeric
 
 __all__ = ["MeasurementWindow", "ChannelID", "HashableNumpyArray", "TimeType", "time_from_float", "DocStringABCMeta",
-           "SingletonABCMeta", "SequenceProxy"]
+           "SingletonABCMeta", "SequenceProxy", "frozendict"]
 
 MeasurementWindow = typing.Tuple[str, numbers.Real, numbers.Real]
 ChannelID = typing.Union[str, int]

--- a/tests/_program/transformation_tests.py
+++ b/tests/_program/transformation_tests.py
@@ -3,8 +3,10 @@ from unittest import mock
 
 import numpy as np
 
+
+from qupulse.expressions import ExpressionScalar
 from qupulse._program.transformation import LinearTransformation, Transformation, IdentityTransformation,\
-    ChainedTransformation, ParallelConstantTransformation, chain_transformations, OffsetTransformation,\
+    ChainedTransformation, ParallelChannelTransformation, chain_transformations, OffsetTransformation,\
     ScalingTransformation
 
 
@@ -286,62 +288,61 @@ class ChainedTransformationTests(unittest.TestCase):
         self.assertFalse(trafo.is_constant_invariant())
 
 
-class ParallelConstantChannelTransformationTests(unittest.TestCase):
+class ParallelChannelTransformationTests(unittest.TestCase):
     def test_init(self):
-        channels = {'X': 2, 'Y': 4.4}
+        channels = {'X': 2, 'Y': 4.4, 'Z': ExpressionScalar('t')}
 
-        trafo = ParallelConstantTransformation(channels)
+        trafo = ParallelChannelTransformation(channels)
 
         self.assertEqual(trafo._channels, channels)
-        self.assertTrue(all(isinstance(v, float) for v in trafo._channels.values()))
-
-        self.assertEqual(trafo.compare_key, (('X', 2.), ('Y', 4.4)))
 
         self.assertEqual(trafo.get_input_channels(set()), set())
         self.assertEqual(trafo.get_input_channels({'X'}), set())
-        self.assertEqual(trafo.get_input_channels({'Z'}), {'Z'})
-        self.assertEqual(trafo.get_input_channels({'X', 'Z'}), {'Z'})
+        self.assertEqual(trafo.get_input_channels({'K'}), {'K'})
+        self.assertEqual(trafo.get_input_channels({'X', 'Z', 'K'}), {'K'})
 
-        self.assertEqual(trafo.get_output_channels(set()), {'X', 'Y'})
-        self.assertEqual(trafo.get_output_channels({'X'}), {'X', 'Y'})
-        self.assertEqual(trafo.get_output_channels({'X', 'Z'}), {'X', 'Y', 'Z'})
+        self.assertEqual(trafo.get_output_channels(set()), {'X', 'Y', 'Z'})
+        self.assertEqual(trafo.get_output_channels({'X'}), {'X', 'Y', 'Z'})
+        self.assertEqual(trafo.get_output_channels({'X', 'Z', 'K'}), {'X', 'Y', 'Z', 'K'})
 
     def test_trafo(self):
-        channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantTransformation(channels)
+        channels = {'X': 2, 'Y': 4.4, 'Z': ExpressionScalar('t')}
+        trafo = ParallelChannelTransformation(channels)
 
         n_points = 17
         time = np.arange(17, dtype=float)
 
         expected_overwrites = {'X': np.full((n_points,), 2.),
-                               'Y': np.full((n_points,), 4.4)}
+                               'Y': np.full((n_points,), 4.4),
+                               'Z': time}
 
         empty_input_result = trafo(time, {})
         np.testing.assert_equal(empty_input_result, expected_overwrites)
 
-        z_input_result = trafo(time, {'Z': np.sin(time)})
-        np.testing.assert_equal(z_input_result, {'Z': np.sin(time), **expected_overwrites})
+        k_input = {'K': np.sin(time)}
+        k_input_result = trafo(time, k_input)
+        np.testing.assert_equal(k_input_result, {**k_input, **expected_overwrites})
 
         x_input_result = trafo(time, {'X': np.cos(time)})
-        np.testing.assert_equal(empty_input_result, expected_overwrites)
+        np.testing.assert_equal(x_input_result, expected_overwrites)
 
-        x_z_input_result = trafo(time, {'X': np.cos(time), 'Z': np.sin(time)})
-        np.testing.assert_equal(z_input_result, {'Z': np.sin(time), **expected_overwrites})
+        x_k_input_result = trafo(time, {'X': np.cos(time), 'K': np.sin(time)})
+        np.testing.assert_equal(x_k_input_result, {'K': np.sin(time), **expected_overwrites})
 
     def test_repr(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantTransformation(channels)
+        trafo = ParallelChannelTransformation(channels)
         self.assertEqual(trafo, eval(repr(trafo)))
 
     def test_scalar_trafo_works(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantTransformation(channels)
+        trafo = ParallelChannelTransformation(channels)
 
         assert_scalar_trafo_works(self, trafo, {'a': 0., 'b': 0.3, 'c': 0.6})
 
     def test_constant_propagation(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantTransformation(channels)
+        trafo = ParallelChannelTransformation(channels)
         self.assertTrue(trafo.is_constant_invariant())
 
 
@@ -379,7 +380,7 @@ class TestChaining(unittest.TestCase):
 
 class TestOffsetTransformation(unittest.TestCase):
     def setUp(self) -> None:
-        self.offsets = {'A': 1., 'B': 1.2}
+        self.offsets = {'A': 1., 'B': 1.2, 'C': ExpressionScalar('t')}
 
     def test_init(self):
         trafo = OffsetTransformation(self.offsets)
@@ -390,26 +391,29 @@ class TestOffsetTransformation(unittest.TestCase):
 
     def test_get_input_channels(self):
         trafo = OffsetTransformation(self.offsets)
-        channels = {'A', 'C'}
+        channels = {'A', 'K'}
         self.assertIs(channels, trafo.get_input_channels(channels))
         self.assertIs(channels, trafo.get_output_channels(channels))
 
     def test_compare_key(self):
         trafo = OffsetTransformation(self.offsets)
         _ = hash(trafo)
-        self.assertEqual(frozenset([('A', 1.), ('B', 1.2)]), trafo.compare_key)
+        self.assertEqual(trafo, OffsetTransformation(self.offsets))
+        self.assertEqual({trafo}, {OffsetTransformation(self.offsets), trafo})
 
     def test_trafo(self):
         trafo = OffsetTransformation(self.offsets)
 
         time = np.asarray([.5, .6])
-        in_data = {'A': np.asarray([.1, .2]), 'C': np.asarray([3., 4.])}
+        in_data = {'A': np.asarray([.1, .2]),
+                   'C': np.asarray([.5, .6]),
+                   'K': np.asarray([3., 4.])}
 
-        expected = {'A': np.asarray([1.1, 1.2]), 'C': in_data['C']}
+        expected = {'A': np.asarray([1.1, 1.2]), 'C': in_data['C'] + time, 'K': in_data['K']}
 
         out_data = trafo(time, in_data)
 
-        self.assertIs(expected['C'], out_data['C'])
+        self.assertIs(expected['K'], out_data['K'])
         np.testing.assert_equal(expected, out_data)
 
     def test_repr(self):
@@ -422,12 +426,15 @@ class TestOffsetTransformation(unittest.TestCase):
 
     def test_constant_propagation(self):
         trafo = OffsetTransformation(self.offsets)
-        self.assertTrue(trafo.is_constant_invariant())
+        self.assertFalse(trafo.is_constant_invariant())
+        constant_trafo = OffsetTransformation({'a': 7, 'b': 8.})
+        self.assertTrue(constant_trafo.is_constant_invariant())
 
 
 class TestScalingTransformation(unittest.TestCase):
     def setUp(self) -> None:
-        self.scales = {'A': 1.5, 'B': 1.2}
+        self.constant_scales = {'A': 1.5, 'B': 1.2}
+        self.scales = {'A': 1.5, 'B': 1.2, 'C': ExpressionScalar('t')}
 
     def test_init(self):
         trafo = ScalingTransformation(self.scales)
@@ -443,19 +450,23 @@ class TestScalingTransformation(unittest.TestCase):
 
     def test_compare_key(self):
         trafo = OffsetTransformation(self.scales)
+        const_trafo = OffsetTransformation(self.constant_scales)
         _ = hash(trafo)
-        self.assertEqual(frozenset([('A', 1.5), ('B', 1.2)]), trafo.compare_key)
+        self.assertEqual(trafo, trafo)
+        self.assertNotEqual(trafo, const_trafo)
+        self.assertEqual({trafo}, {trafo, OffsetTransformation(self.scales)})
+        self.assertEqual({trafo, const_trafo}, {trafo, OffsetTransformation(self.constant_scales)})
 
     def test_trafo(self):
         trafo = ScalingTransformation(self.scales)
 
         time = np.asarray([.5, .6])
-        in_data = {'A': np.asarray([.1, .2]), 'C': np.asarray([3., 4.])}
-        expected = {'A': np.asarray([.1 * 1.5, .2 * 1.5]), 'C': in_data['C']}
+        in_data = {'A': np.asarray([.1, .2]), 'C': np.asarray([3., 4.]), 'K': np.asarray([5., 6.])}
+        expected = {'A': in_data['A'] * 1.5, 'C': in_data['C'] * time, 'K': in_data['K']}
 
         out_data = trafo(time, in_data)
 
-        self.assertIs(expected['C'], out_data['C'])
+        self.assertIs(expected['K'], out_data['K'])
         np.testing.assert_equal(expected, out_data)
 
     def test_repr(self):
@@ -468,4 +479,6 @@ class TestScalingTransformation(unittest.TestCase):
 
     def test_constant_propagation(self):
         trafo = ScalingTransformation(self.scales)
-        self.assertTrue(trafo.is_constant_invariant())
+        const_trafo = ScalingTransformation(self.constant_scales)
+        self.assertFalse(trafo.is_constant_invariant())
+        self.assertTrue(const_trafo.is_constant_invariant())

--- a/tests/_program/transformation_tests.py
+++ b/tests/_program/transformation_tests.py
@@ -20,6 +20,9 @@ class TransformationStub(Transformation):
     def get_input_channels(self, output_channels):
         raise NotImplementedError()
 
+    def get_constant_output_channels(self, input_channels):
+        raise NotImplementedError()
+
     @property
     def compare_key(self):
         return id(self)
@@ -169,6 +172,9 @@ class LinearTransformationTests(unittest.TestCase):
         trafo = LinearTransformation(matrix, in_chs, out_chs)
         self.assertTrue(trafo.is_constant_invariant())
 
+    def test_time_dependence(self):
+        raise NotImplementedError()
+
 
 class IdentityTransformationTests(unittest.TestCase):
     def test_compare_key(self):
@@ -305,6 +311,8 @@ class ParallelChannelTransformationTests(unittest.TestCase):
         self.assertEqual(trafo.get_output_channels({'X'}), {'X', 'Y', 'Z'})
         self.assertEqual(trafo.get_output_channels({'X', 'Z', 'K'}), {'X', 'Y', 'Z', 'K'})
 
+        self.assertEqual(trafo.get_constant_output_channels({'X', 'Y', 'Z', 'K'}), {'X', 'Y', 'K'})
+
     def test_trafo(self):
         channels = {'X': 2, 'Y': 4.4, 'Z': ExpressionScalar('t')}
         trafo = ParallelChannelTransformation(channels)
@@ -345,6 +353,9 @@ class ParallelChannelTransformationTests(unittest.TestCase):
         trafo = ParallelChannelTransformation(channels)
         self.assertTrue(trafo.is_constant_invariant())
 
+    def test_time_dependence(self):
+        raise NotImplementedError()
+
 
 class TestChaining(unittest.TestCase):
     def test_identity_result(self):
@@ -376,6 +387,9 @@ class TestChaining(unittest.TestCase):
         result = chain_transformations(trafo, IdentityTransformation(), trafo)
 
         self.assertEqual(result, expected)
+
+    def test_constant_propagation(self):
+        raise NotImplementedError()
 
 
 class TestOffsetTransformation(unittest.TestCase):
@@ -430,6 +444,9 @@ class TestOffsetTransformation(unittest.TestCase):
         constant_trafo = OffsetTransformation({'a': 7, 'b': 8.})
         self.assertTrue(constant_trafo.is_constant_invariant())
 
+    def test_time_dependence(self):
+        raise NotImplementedError()
+
 
 class TestScalingTransformation(unittest.TestCase):
     def setUp(self) -> None:
@@ -482,3 +499,6 @@ class TestScalingTransformation(unittest.TestCase):
         const_trafo = ScalingTransformation(self.constant_scales)
         self.assertFalse(trafo.is_constant_invariant())
         self.assertTrue(const_trafo.is_constant_invariant())
+
+    def test_time_dependence(self):
+        raise NotImplementedError()

--- a/tests/_program/transformation_tests.py
+++ b/tests/_program/transformation_tests.py
@@ -4,7 +4,7 @@ from unittest import mock
 import numpy as np
 
 from qupulse._program.transformation import LinearTransformation, Transformation, IdentityTransformation,\
-    ChainedTransformation, ParallelConstantChannelTransformation, chain_transformations, OffsetTransformation,\
+    ChainedTransformation, ParallelConstantTransformation, chain_transformations, OffsetTransformation,\
     ScalingTransformation
 
 
@@ -290,7 +290,7 @@ class ParallelConstantChannelTransformationTests(unittest.TestCase):
     def test_init(self):
         channels = {'X': 2, 'Y': 4.4}
 
-        trafo = ParallelConstantChannelTransformation(channels)
+        trafo = ParallelConstantTransformation(channels)
 
         self.assertEqual(trafo._channels, channels)
         self.assertTrue(all(isinstance(v, float) for v in trafo._channels.values()))
@@ -308,7 +308,7 @@ class ParallelConstantChannelTransformationTests(unittest.TestCase):
 
     def test_trafo(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantChannelTransformation(channels)
+        trafo = ParallelConstantTransformation(channels)
 
         n_points = 17
         time = np.arange(17, dtype=float)
@@ -330,18 +330,18 @@ class ParallelConstantChannelTransformationTests(unittest.TestCase):
 
     def test_repr(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantChannelTransformation(channels)
+        trafo = ParallelConstantTransformation(channels)
         self.assertEqual(trafo, eval(repr(trafo)))
 
     def test_scalar_trafo_works(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantChannelTransformation(channels)
+        trafo = ParallelConstantTransformation(channels)
 
         assert_scalar_trafo_works(self, trafo, {'a': 0., 'b': 0.3, 'c': 0.6})
 
     def test_constant_propagation(self):
         channels = {'X': 2, 'Y': 4.4}
-        trafo = ParallelConstantChannelTransformation(channels)
+        trafo = ParallelConstantTransformation(channels)
         self.assertTrue(trafo.is_constant_invariant())
 
 

--- a/tests/pulses/arithmetic_pulse_template_tests.py
+++ b/tests/pulses/arithmetic_pulse_template_tests.py
@@ -240,23 +240,31 @@ class ArithmeticPulseTemplateTest(unittest.TestCase):
 
         with mock.patch.object(ArithmeticPulseTemplate, '_parse_operand',
                                return_value=scalar) as parse_operand:
-            arith = ArithmeticPulseTemplate(lhs, '/', non_pt)
-            parse_operand.assert_called_once_with(non_pt, lhs.defined_channels)
-            self.assertEqual(lhs, arith.lhs)
-            self.assertEqual(scalar, arith.rhs)
-            self.assertEqual(lhs, arith._pulse_template)
-            self.assertEqual(scalar, arith._scalar)
-            self.assertEqual('/', arith._arithmetic_operator)
+            with mock.patch('qupulse.pulses.arithmetic_pulse_template._is_time_dependent', return_value=False):
+                arith = ArithmeticPulseTemplate(lhs, '/', non_pt)
+                parse_operand.assert_called_once_with(non_pt, lhs.defined_channels)
+                self.assertEqual(lhs, arith.lhs)
+                self.assertEqual(scalar, arith.rhs)
+                self.assertEqual(lhs, arith._pulse_template)
+                self.assertEqual(scalar, arith._scalar)
+                self.assertEqual('/', arith._arithmetic_operator)
 
         with mock.patch.object(ArithmeticPulseTemplate, '_parse_operand',
                                return_value=scalar) as parse_operand:
-            arith = ArithmeticPulseTemplate(non_pt, '-', rhs)
-            parse_operand.assert_called_once_with(non_pt, rhs.defined_channels)
-            self.assertEqual(scalar, arith.lhs)
-            self.assertEqual(rhs, arith.rhs)
-            self.assertEqual(rhs, arith._pulse_template)
-            self.assertEqual(scalar, arith._scalar)
-            self.assertEqual('-', arith._arithmetic_operator)
+            with mock.patch('qupulse.pulses.arithmetic_pulse_template._is_time_dependent', return_value=False):
+                arith = ArithmeticPulseTemplate(non_pt, '-', rhs)
+                parse_operand.assert_called_once_with(non_pt, rhs.defined_channels)
+                self.assertEqual(scalar, arith.lhs)
+                self.assertEqual(rhs, arith.rhs)
+                self.assertEqual(rhs, arith._pulse_template)
+                self.assertEqual(scalar, arith._scalar)
+                self.assertEqual('-', arith._arithmetic_operator)
+
+        with mock.patch.object(ArithmeticPulseTemplate, '_parse_operand',
+                               return_value=scalar) as parse_operand:
+            with mock.patch('qupulse.pulses.arithmetic_pulse_template._is_time_dependent', return_value=True):
+                with self.assertRaises(TypeError):
+                    ArithmeticPulseTemplate(non_pt, '-', RepetitionPT(rhs, 3))
 
     def test_parse_operand(self):
         operand = {'a': 3, 'b': 'x'}

--- a/tests/pulses/arithmetic_pulse_template_tests.py
+++ b/tests/pulses/arithmetic_pulse_template_tests.py
@@ -536,8 +536,10 @@ class ArithmeticPulseTemplateTest(unittest.TestCase):
         self.assertEqual({'x', 'y', 'foo', 'bar'}, arith.parameter_names)
 
         pt = DummyPulseTemplate(defined_channels={'a'}, parameter_names={'foo', 'bar'})
-        mapping = {'a': 'x', 'b': 'y'}
         self.assertEqual(frozenset({'x', 'y'}), arith._scalar_operand_parameters)
+        self.assertEqual({'x', 'y', 'foo', 'bar'}, arith.parameter_names)
+
+        arith = ArithmeticPulseTemplate(pt, '+', scalar + '+t')
         self.assertEqual({'x', 'y', 'foo', 'bar'}, arith.parameter_names)
 
     def test_try_operation(self):

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -4,6 +4,7 @@ from unittest import mock
 import numpy
 
 from qupulse.parameter_scope import DictScope
+from qupulse.pulses import RepetitionPT
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform, MappingPulseTemplate,\
     ChannelMappingException, AtomicMultiChannelPulseTemplate, ParallelConstantChannelPulseTemplate,\
     TransformingWaveform, ParallelChannelTransformation
@@ -358,6 +359,14 @@ class ParallelConstantChannelPulseTemplateTests(unittest.TestCase):
         self.assertEqual({'M'}, pccpt.measurement_names)
         self.assertEqual({'a', 'c'}, pccpt.transformation_parameters)
         self.assertIs(template.duration, pccpt.duration)
+
+        non_atomic_pt = RepetitionPT(template, 5)
+        ParallelConstantChannelPulseTemplate(non_atomic_pt, overwritten_channels)
+        with self.assertRaises(TypeError):
+            overwritten_channels['T'] = 'a * t'
+            ParallelConstantChannelPulseTemplate(non_atomic_pt, overwritten_channels)
+
+        ParallelConstantChannelPulseTemplate(template, overwritten_channels)
 
     def test_missing_implementations(self):
         pccpt = ParallelConstantChannelPulseTemplate(DummyPulseTemplate(), {})

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -483,6 +483,11 @@ class ParallelChannelPulseTemplateTests(unittest.TestCase):
         }
         np.testing.assert_equal(expected_values, vals)
 
+    def test_parameter_names(self):
+        inner = ConstantPT(1.4, {'a': ExpressionScalar('x'), 'b': 1.})
+        pc = ParallelChannelPulseTemplate(inner, {'c': 'sin(2*pi*f*t)', 'd': 'k'})
+        self.assertEqual({'x', 'f', 'k'}, pc.parameter_names)
+
 
 class ParallelChannelPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
     @property

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -6,7 +6,7 @@ import numpy
 from qupulse.parameter_scope import DictScope
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform, MappingPulseTemplate,\
     ChannelMappingException, AtomicMultiChannelPulseTemplate, ParallelConstantChannelPulseTemplate,\
-    TransformingWaveform, ParallelConstantChannelTransformation
+    TransformingWaveform, ParallelConstantTransformation
 from qupulse.pulses.parameters import ParameterConstraint, ParameterConstraintViolation, ConstantParameter
 from qupulse.expressions import ExpressionScalar, Expression
 from qupulse._program.transformation import LinearTransformation, chain_transformations
@@ -419,7 +419,7 @@ class ParallelConstantChannelPulseTemplateTests(unittest.TestCase):
         kwargs = {**other_kwargs, 'scope': scope, 'global_transformation': None}
 
         expected_overwritten_channels = {'O': 1.2, 'Z': 3.4}
-        expected_transformation = ParallelConstantChannelTransformation(expected_overwritten_channels)
+        expected_transformation = ParallelConstantTransformation(expected_overwritten_channels)
         expected_kwargs = {**kwargs, 'global_transformation': expected_transformation}
 
         with mock.patch.object(template, '_create_program', spec=template._create_program) as cp_mock:
@@ -444,7 +444,7 @@ class ParallelConstantChannelPulseTemplateTests(unittest.TestCase):
 
         parameters = {'c': 1.2, 'a': 3.4}
         expected_overwritten_channels = {'K': 1.2, 'Z': 3.4}
-        expected_transformation = ParallelConstantChannelTransformation(expected_overwritten_channels)
+        expected_transformation = ParallelConstantTransformation(expected_overwritten_channels)
         expected_waveform = TransformingWaveform(template.waveform, expected_transformation)
 
         resulting_waveform = pccpt.build_waveform(parameters.copy(), channel_mapping.copy())

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -6,7 +6,7 @@ import numpy
 from qupulse.parameter_scope import DictScope
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform, MappingPulseTemplate,\
     ChannelMappingException, AtomicMultiChannelPulseTemplate, ParallelConstantChannelPulseTemplate,\
-    TransformingWaveform, ParallelConstantTransformation
+    TransformingWaveform, ParallelChannelTransformation
 from qupulse.pulses.parameters import ParameterConstraint, ParameterConstraintViolation, ConstantParameter
 from qupulse.expressions import ExpressionScalar, Expression
 from qupulse._program.transformation import LinearTransformation, chain_transformations
@@ -419,7 +419,7 @@ class ParallelConstantChannelPulseTemplateTests(unittest.TestCase):
         kwargs = {**other_kwargs, 'scope': scope, 'global_transformation': None}
 
         expected_overwritten_channels = {'O': 1.2, 'Z': 3.4}
-        expected_transformation = ParallelConstantTransformation(expected_overwritten_channels)
+        expected_transformation = ParallelChannelTransformation(expected_overwritten_channels)
         expected_kwargs = {**kwargs, 'global_transformation': expected_transformation}
 
         with mock.patch.object(template, '_create_program', spec=template._create_program) as cp_mock:
@@ -444,7 +444,7 @@ class ParallelConstantChannelPulseTemplateTests(unittest.TestCase):
 
         parameters = {'c': 1.2, 'a': 3.4}
         expected_overwritten_channels = {'K': 1.2, 'Z': 3.4}
-        expected_transformation = ParallelConstantTransformation(expected_overwritten_channels)
+        expected_transformation = ParallelChannelTransformation(expected_overwritten_channels)
         expected_waveform = TransformingWaveform(template.waveform, expected_transformation)
 
         resulting_waveform = pccpt.build_waveform(parameters.copy(), channel_mapping.copy())


### PR DESCRIPTION
The original idea was to enable time dependent expressions for arithmetic pulse templates. However this will not produce reasonable results when the other PT is not atomic because the waveform i.e. the transformation will not get the correct time during sampling of a composite PT.

One could circumvent this by adding a time delay for SequencePT and ForLoopPT but if there is a RepetitionPT it cannot be handled correctly because the waveform itself is not actually repeated i.e. it needs to be unrolled.

We could adapt the `Program` type to be more powerful and cover the representation of a modulated or otherwise altered sub-program. This could allow efficient playback on supporting hardware.

The current solution is to enforce atomicity via the newly added `_is_atomic` method.

 - [x] Remove composite PT support
 - [x] Add transformation unit tests
 - [x] Update docstring 

Examples will be added in a separate PR.