### PR TITLE
Add pulse template creation helpers

### DIFF
--- a/changes.d/710.feature
+++ b/changes.d/710.feature
@@ -1,0 +1,2 @@
+Add `with_` family of helper methods to `PulseTemplate` to allow convinient and easily discoverable pulse template
+combination.

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -329,9 +329,9 @@ class ParallelConstantChannelPulseTemplate(PulseTemplate):
         data['overwritten_channels'] = self._overwritten_channels
         return data
 
-    def with_constant_channels(self, values: Mapping[ChannelID, ExpressionLike]) -> 'PulseTemplate':
+    def with_parallel_channels(self, values: Mapping[ChannelID, ExpressionLike]) -> 'PulseTemplate':
         if self.identifier:
-            return super().with_constant_channels(values)
+            return super().with_parallel_channels(values)
         else:
             return ParallelConstantChannelPulseTemplate(
                 self._template,

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -91,6 +91,20 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
 
         self._register(registry=registry)
 
+    def with_parallel_atomic(self, *parallel: 'AtomicPulseTemplate') -> 'AtomicPulseTemplate':
+        from qupulse.pulses import AtomicMultiChannelPT
+        if parallel:
+            if self.identifier:
+                return AtomicMultiChannelPT(self, *parallel)
+            else:
+                return AtomicMultiChannelPT(
+                    *self._subtemplates, *parallel,
+                    measurements=self.measurement_declarations,
+                    parameter_constraints=self.parameter_constraints,
+                )
+        else:
+            return self
+
     @property
     def duration(self) -> ExpressionScalar:
         if self._duration is None:

--- a/qupulse/pulses/multi_channel_pulse_template.py
+++ b/qupulse/pulses/multi_channel_pulse_template.py
@@ -315,6 +315,15 @@ class ParallelConstantChannelPulseTemplate(PulseTemplate):
         data['overwritten_channels'] = self._overwritten_channels
         return data
 
+    def with_constant_channels(self, values: Mapping[ChannelID, ExpressionLike]) -> 'PulseTemplate':
+        if self.identifier:
+            return super().with_constant_channels(values)
+        else:
+            return ParallelConstantChannelPulseTemplate(
+                self._template,
+                {**self._overwritten_channels, **values},
+            )
+
 
 class ChannelMappingException(Exception):
     def __init__(self, obj1, obj2, intersect_set):

--- a/qupulse/pulses/parameters.py
+++ b/qupulse/pulses/parameters.py
@@ -239,10 +239,13 @@ class ParameterConstraint(AnonymousSerializable):
         return str(self)
 
 
+ConstraintLike = Union[sympy.Expr, str, ParameterConstraint]
+
+
 class ParameterConstrainer:
     """A class that implements the testing of parameter constraints. It is used by the subclassing pulse templates."""
     def __init__(self, *,
-                 parameter_constraints: Optional[Iterable[Union[str, ParameterConstraint]]]) -> None:
+                 parameter_constraints: Optional[Iterable[ConstraintLike]]) -> None:
         if parameter_constraints is None:
             self._parameter_constraints = []
         else:

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -246,6 +246,18 @@ class PulseTemplate(Serializable):
                                           global_transformation=global_transformation,
                                           parent_loop=parent_loop)
 
+    def with_constant_channels(self, values: Mapping[ChannelID, ExpressionLike]) -> 'PulseTemplate':
+        """Create a new pulse template that sets the given channels to the corresponding values.
+
+        Args:
+            values: Constant values to be set for each channel.
+        """
+        from qupulse.pulses.multi_channel_pulse_template import ParallelConstantChannelPulseTemplate
+        return ParallelConstantChannelPulseTemplate(
+            self,
+            values
+        )
+
     def __format__(self, format_spec: str):
         if format_spec == '':
             format_spec = self._DEFAULT_FORMAT_SPEC

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -246,14 +246,16 @@ class PulseTemplate(Serializable):
                                           global_transformation=global_transformation,
                                           parent_loop=parent_loop)
 
-    def with_constant_channels(self, values: Mapping[ChannelID, ExpressionLike]) -> 'PulseTemplate':
+    def with_parallel_channels(self, values: Mapping[ChannelID, ExpressionLike]) -> 'PulseTemplate':
         """Create a new pulse template that sets the given channels to the corresponding values.
 
+        See :class:`~qupulse.pulses.ParallelChannelPulseTemplate` for implementation details and restictions.
+
         Args:
-            values: Constant values to be set for each channel.
+            values: Values to be set for each channel.
         """
-        from qupulse.pulses.multi_channel_pulse_template import ParallelConstantChannelPulseTemplate
-        return ParallelConstantChannelPulseTemplate(
+        from qupulse.pulses.multi_channel_pulse_template import ParallelChannelPulseTemplate
+        return ParallelChannelPulseTemplate(
             self,
             values
         )

--- a/qupulse/pulses/repetition_pulse_template.py
+++ b/qupulse/pulses/repetition_pulse_template.py
@@ -70,6 +70,17 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
 
         self._register(registry=registry)
 
+    def with_repetition(self, repetition_count: Union[int, str, ExpressionScalar]) -> 'PulseTemplate':
+        if self.identifier:
+            return RepetitionPulseTemplate(self, repetition_count)
+        else:
+            return RepetitionPulseTemplate(
+                self.body,
+                self.repetition_count * repetition_count,
+                parameter_constraints=self.parameter_constraints,
+                measurements=self.measurement_declarations
+            )
+
     @property
     def repetition_count(self) -> ExpressionScalar:
         """The amount of repetitions. Either a constant integer or a ParameterDeclaration object."""

--- a/qupulse/pulses/sequence_pulse_template.py
+++ b/qupulse/pulses/sequence_pulse_template.py
@@ -2,7 +2,7 @@
 combines several other PulseTemplate objects for sequential execution."""
 
 import numpy as np
-from typing import Dict, List, Set, Optional, Any, AbstractSet, Union, Callable, cast
+from typing import Dict, List, Set, Optional, Any, AbstractSet, Union, Callable, cast, Iterable
 from numbers import Real
 import functools
 import warnings

--- a/qupulse/pulses/sequence_pulse_template.py
+++ b/qupulse/pulses/sequence_pulse_template.py
@@ -76,17 +76,6 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
 
         self._register(registry=registry)
 
-    def with_appended(self, *appended: 'PulseTemplate'):
-        if appended:
-            if self.identifier:
-                return SequencePulseTemplate(self, *appended)
-            else:
-                return SequencePulseTemplate(*self.__subtemplates, *appended,
-                                             parameter_constraints=self.parameter_constraints,
-                                             measurements=self.measurement_declarations)
-        else:
-            return self
-
     @classmethod
     def concatenate(cls, *pulse_templates: Union[PulseTemplate, MappingTuple], **kwargs) -> 'SequencePulseTemplate':
         """Sequences the given pulse templates by creating a SequencePulseTemplate. Pulse templates that are

--- a/qupulse/pulses/time_reversal_pulse_template.py
+++ b/qupulse/pulses/time_reversal_pulse_template.py
@@ -19,6 +19,13 @@ class TimeReversalPulseTemplate(PulseTemplate):
         self._inner = inner
         self._register(registry=registry)
 
+    def with_time_reversal(self) -> 'PulseTemplate':
+        from qupulse.pulses import TimeReversalPT
+        if self.identifier:
+            return TimeReversalPT(self)
+        else:
+            return self._inner
+
     @property
     def parameter_names(self) -> Set[str]:
         return self._inner.parameter_names

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -8,6 +8,8 @@ import sympy
 from qupulse.parameter_scope import Scope, DictScope
 from qupulse.utils.types import ChannelID
 from qupulse.expressions import Expression, ExpressionScalar
+from qupulse.pulses import ConstantPT, FunctionPT, RepetitionPT, ForLoopPT, ParallelChannelPT, MappingPT,\
+    TimeReversalPT, AtomicMultiChannelPT
 from qupulse.pulses.pulse_template import AtomicPulseTemplate, PulseTemplate
 from qupulse.pulses.parameters import Parameter, ConstantParameter, ParameterNotProvidedException
 from qupulse.pulses.multi_channel_pulse_template import MultiChannelWaveform
@@ -361,6 +363,52 @@ class PulseTemplateTest(unittest.TestCase):
         self.assertEqual("PulseTemplateStub(identifier='asd')", format(a))
         self.assertEqual("PulseTemplateStub(identifier='asd', duration='5')",
                          "{:identifier;duration}".format(a))
+
+
+class WithMethodTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fpt = FunctionPT(1.4, 'sin(f*t)', 'X')
+        self.cpt = ConstantPT(1.4, {'Y': 'start + idx * step'})
+    def test_parallel_channels(self):
+        expected = ParallelChannelPT(self.fpt, {'K': 'k'})
+        actual = self.fpt.with_parallel_channels({'K': 'k'})
+        self.assertEqual(expected, actual)
+
+    def test_parallel_channels_optimization(self):
+        expected = ParallelChannelPT(self.fpt, {'K': 'k', 'C': 'c'})
+        actual = self.fpt.with_parallel_channels({'K': 'k'}).with_parallel_channels({'C': 'c'})
+        self.assertEqual(expected, actual)
+
+    def test_iteration(self):
+        expected = ForLoopPT(self.cpt, 'idx', 'n_steps')
+        actual = self.cpt.with_iteration('idx', 'n_steps')
+        self.assertEqual(expected, actual)
+
+    def test_appended(self):
+        expected = self.fpt @ self.fpt.with_time_reversal()
+        actual = self.fpt.with_appended(self.fpt.with_time_reversal())
+        self.assertEqual(expected, actual)
+
+    def test_repetition(self):
+        expected = RepetitionPT(self.fpt, 6)
+        actual = self.fpt.with_repetition(6)
+        self.assertEqual(expected, actual)
+
+    def test_repetition_optimization(self):
+        # unstable test due to flimsy expression equality :(
+        expected = RepetitionPT(self.fpt, ExpressionScalar(6) * 2)
+        actual = self.fpt.with_repetition(6).with_repetition(2)
+        self.assertEqual(expected, actual)
+
+    def test_time_reversal(self):
+        expected = TimeReversalPT(self.fpt)
+        actual = self.fpt.with_time_reversal()
+        self.assertEqual(expected, actual)
+
+    def test_parallel_atomic(self):
+        expected = AtomicMultiChannelPT(self.fpt, self.cpt)
+        actual = self.fpt.with_parallel_atomic(self.cpt)
+        self.assertEqual(expected, actual)
 
 
 class AtomicPulseTemplateTests(unittest.TestCase):


### PR DESCRIPTION
 - [x] Add `with_constant_channels`, `with_repetition`, `with_mapping`, `with_iteration`, `with_time_reversal`, `with_appended`
 - [x] Add specializations for optimization
 - [x] Add testing
 - [x] Rename `with_constant_channels` to `with_parallel_channels` since it will allow time dependet expressions in some cases when #704 is merged
 - [x] Add newspiece

Documentation is handled in a different PR and tracked via the issue #710 