### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         time-type: ["fractions", "gmpy2"]
     env:
       INSTALL_EXTRAS: tests,plotting,zurich-instruments,tektronix,tabor-instruments

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python -m pip install -e git+https://github.com/qutech/qupulse.git#egg=qupulse[d
 which will clone the github repository to `./src/qupulse` and do an editable/development install. 
 
 ### Requirements and dependencies
-qupulse requires at least Python 3.7 and is tested on 3.7, 3.8 and 3.9. It relies on some external Python packages as dependencies. 
+qupulse requires at least Python 3.8 and is tested on 3.8, 3.9 and 3.10. It relies on some external Python packages as dependencies. 
 We intentionally did not restrict versions of dependencies in the install scripts to not unnecessarily prevent usage of newer releases of dependencies that might be compatible. However, if qupulse does encounter problems with a particular dependency version please file an issue. 
 
 The backend for TaborAWGs requires packages that can be found [here](https://git.rwth-aachen.de/qutech/python-TaborDriver). As a shortcut you can install it from the python interpreter via `qupulse.hardware.awgs.install_requirements('tabor')`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 package_dir =
     qupulse=qupulse
     qctoolkit=qctoolkit
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     sympy>=1.1.1
     numpy


### PR DESCRIPTION
Push minimal python version to 3.8 and add python 3.10 to test matrix

Closes #760 