### PR TITLE
Optimize unsafe_sample

### DIFF
--- a/qupulse/program/waveforms.py
+++ b/qupulse/program/waveforms.py
@@ -369,8 +369,8 @@ class TableWaveform(Waveform):
             entries = self._table
 
         for entry1, entry2 in pairwise(entries):
-            indices = slice(np.searchsorted(sample_times, entry1.t, 'left'),
-                            np.searchsorted(sample_times, entry2.t, 'right'))
+            indices = slice(sample_times.searchsorted(entry1.t, 'left'),
+                            sample_times.searchsorted(entry2.t, 'right'))
             output_array[indices] = \
                 entry2.interp((float(entry1.t), entry1.v),
                               (float(entry2.t), entry2.v),
@@ -626,7 +626,7 @@ class SequenceWaveform(Waveform):
             # indexing in numpy and their copy/reference behaviour
             end = time + subwaveform.duration
 
-            indices = slice(*np.searchsorted(sample_times, (float(time), float(end)), 'left'))
+            indices = slice(*sample_times.searchsorted((float(time), float(end)), 'left'))
             subwaveform.unsafe_sample(channel=channel,
                                       sample_times=sample_times[indices]-np.float64(time),
                                       output_array=output_array[indices])
@@ -843,7 +843,7 @@ class RepetitionWaveform(Waveform):
         time = 0
         for _ in range(self._repetition_count):
             end = time + body_duration
-            indices = slice(*np.searchsorted(sample_times, (float(time), float(end)), 'left'))
+            indices = slice(*sample_times.searchsorted((float(time), float(end)), 'left'))
             self._body.unsafe_sample(channel=channel,
                                      sample_times=sample_times[indices] - float(time),
                                      output_array=output_array[indices])


### PR DESCRIPTION
In `unsafe_sample` the `sample_times` is guaranteed to be a numpy array. Calling `searchsorted` from the array is more efficient.

For a small numpy array:
```
In [66]: %timeit sample_times.searchsorted( (0,0), 'left')
1.53 µs ± 63.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [67]: %timeit np.searchsorted(sample_times, (0,0), 'left')
2.73 µs ± 424 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

@terrorfisch 