### PR TITLE
Add floordiv implementation to sympy expression wrapper

### DIFF
--- a/qupulse/expressions/sympy.py
+++ b/qupulse/expressions/sympy.py
@@ -401,6 +401,12 @@ class ExpressionScalar(Expression):
     def __rtruediv__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
         return self.make(self._sympified_expression.__rtruediv__(self._extract_sympified(other)))
 
+    def __floordiv__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
+        return self.make(self._sympified_expression.__floordiv__(self._extract_sympified(other)))
+
+    def __rfloordiv__(self, other: Union['ExpressionScalar', Number, sympy.Expr]) -> 'ExpressionScalar':
+        return self.make(self._sympified_expression.__rfloordiv__(self._extract_sympified(other)))
+
     def __neg__(self) -> 'ExpressionScalar':
         return self.make(self._sympified_expression.__neg__())
 

--- a/tests/expressions/expression_tests.py
+++ b/tests/expressions/expression_tests.py
@@ -391,6 +391,9 @@ class ExpressionScalarTests(unittest.TestCase):
         self.assertExpressionEqual(a - b, -(b - a))
         self.assertExpressionEqual(a * b, b * a)
         self.assertExpressionEqual(a / b, 1 / (b / a))
+        self.assertExpressionEqual(a // 3, ExpressionScalar('floor(a / 3)'))
+        self.assertExpressionEqual(a // 3, ExpressionScalar('a // 3'))
+        self.assertExpressionEqual(3 // a, ExpressionScalar('floor(3 / a)'))
 
     def test_symbolic_math(self):
         a = ExpressionScalar('a')
@@ -400,6 +403,7 @@ class ExpressionScalarTests(unittest.TestCase):
         self.assertExpressionEqual(a - b, -(b - a))
         self.assertExpressionEqual(a * b, b * a)
         self.assertExpressionEqual(a / b, 1 / (b / a))
+        self.assertExpressionEqual(a // b, ExpressionScalar('floor(a / b)'))
 
     def test_sympy_math(self):
         a = ExpressionScalar('a')


### PR DESCRIPTION
The floordiv is required by the protocol.