### PR TITLE
Deprecate Comparable

### DIFF
--- a/qupulse/comparable.py
+++ b/qupulse/comparable.py
@@ -1,11 +1,15 @@
 """This module defines the abstract Comparable class."""
 from abc import abstractmethod
 from typing import Hashable, Any
+import warnings
 
 from qupulse.utils.types import DocStringABCMeta
 
 
 __all__ = ["Comparable"]
+
+
+warnings.warn("qupulse.comparable is deprecated since 0.11 and will be removed in 0.12", DeprecationWarning)
 
 
 class Comparable(metaclass=DocStringABCMeta):

--- a/qupulse/hardware/awgs/base.py
+++ b/qupulse/hardware/awgs/base.py
@@ -12,7 +12,7 @@ from numbers import Real
 from typing import Set, Tuple, Callable, Optional, Mapping, Sequence, List, Union, NamedTuple
 from collections import OrderedDict
 from enum import Enum
-# from itertools import chain
+import warnings
 
 from qupulse.hardware.util import get_sample_times, not_none_indices
 from qupulse.utils.types import ChannelID
@@ -20,7 +20,6 @@ from qupulse.program.linspace import LinSpaceNode, LinSpaceArbitraryWaveform, to
     Increment, Set as LSPSet, LoopLabel, LoopJmp, Wait, Play
 from qupulse.program.loop import Loop
 from qupulse.program.waveforms import Waveform
-from qupulse.comparable import Comparable
 from qupulse.utils.types import TimeType
 
 import numpy
@@ -39,7 +38,7 @@ class AWGAmplitudeOffsetHandling:
     _valid = [IGNORE_OFFSET, CONSIDER_OFFSET]
 
 
-class AWG(Comparable):
+class AWG:
     """An arbitrary waveform generator abstraction class.
 
     It represents a set of channels that have to have(hardware enforced) the same:
@@ -142,6 +141,13 @@ class AWG(Comparable):
     def compare_key(self) -> int:
         """Comparison and hashing is based on the id of the AWG so different devices with the same properties
         are ot equal"""
+        warnings.warn("AWG.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+
+    def __eq__(self, other):
+        return self is other
+
+    def __hash__(self):
         return id(self)
 
     @abstractmethod

--- a/qupulse/hardware/awgs/base.py
+++ b/qupulse/hardware/awgs/base.py
@@ -143,6 +143,7 @@ class AWG:
         are ot equal"""
         warnings.warn("AWG.compare_key is deprecated since 0.11 and will be removed in 0.12",
                       DeprecationWarning, stacklevel=2)
+        return id(self)
 
     def __eq__(self, other):
         return self is other

--- a/qupulse/program/transformation.py
+++ b/qupulse/program/transformation.py
@@ -79,7 +79,7 @@ class IdentityTransformation(Transformation, metaclass=SingletonABCMeta):
         return 0x1234991
 
     def __eq__(self, other):
-        return isinstance(other, IdentityTransformation)
+        return self is other
 
     def get_input_channels(self, output_channels: AbstractSet[ChannelID]) -> AbstractSet[ChannelID]:
         return output_channels
@@ -134,7 +134,9 @@ class ChainedTransformation(Transformation):
         return hash(self._transformations)
 
     def __eq__(self, other):
-        return self._transformations == getattr(other, '_transformations', None)
+        if isinstance(other, ChainedTransformation):
+            return self._transformations == other._transformations
+        return NotImplemented
 
     def chain(self, next_transformation) -> Transformation:
         return chain_transformations(*self.transformations, next_transformation)
@@ -223,11 +225,11 @@ class LinearTransformation(Transformation):
         return hash((self._input_channels, self._output_channels, self._matrix.tobytes()))
 
     def __eq__(self, other):
-        if isinstance(other, type(self)):
+        if isinstance(other, LinearTransformation):
             return (self._input_channels == other._input_channels and
                     self._output_channels == other._output_channels and
                     np.array_equal(self._matrix, other._matrix))
-        return False
+        return NotImplemented
 
     @property
     def compare_key(self) -> Tuple[Tuple[ChannelID], Tuple[ChannelID], bytes]:
@@ -278,7 +280,9 @@ class OffsetTransformation(Transformation):
         return input_channels
 
     def __eq__(self, other):
-        return isinstance(other, OffsetTransformation) and self._offsets == other._offsets
+        if isinstance(other, OffsetTransformation):
+            return self._offsets == other._offsets
+        return NotImplemented
 
     def __hash__(self):
         return hash(self._offsets)
@@ -320,7 +324,9 @@ class ScalingTransformation(Transformation):
         return input_channels
 
     def __eq__(self, other):
-        return isinstance(other, ScalingTransformation) and self._factors == other._factors
+        if isinstance(other, ScalingTransformation):
+            return self._factors == other._factors
+        return NotImplemented
 
     def __hash__(self):
         return hash(self._factors)
@@ -393,7 +399,9 @@ class ParallelChannelTransformation(Transformation):
         return hash(self._channels)
 
     def __eq__(self, other):
-        return isinstance(other, ParallelChannelTransformation) and self._channels == other._channels
+        if isinstance(other, ParallelChannelTransformation):
+            return self._channels == other._channels
+        return NotImplemented
 
     @property
     def compare_key(self) -> Hashable:

--- a/qupulse/program/waveforms.py
+++ b/qupulse/program/waveforms.py
@@ -911,6 +911,14 @@ class TransformingWaveform(Waveform):
         self._cached_data = None
         self._cached_times = lambda: None
 
+    def __hash__(self):
+        return hash((self._inner_waveform, self._transformation))
+
+    def __eq__(self, other):
+        if getattr(other, '__slots__', None) is self.__slots__:
+            return self._inner_waveform == other._inner_waveform and self._transformation == other._transformation
+        return NotImplemented
+
     @classmethod
     def from_transformation(cls, inner_waveform: Waveform, transformation: Transformation) -> Waveform:
         constant_values = inner_waveform.constant_value_dict()

--- a/qupulse/program/waveforms.py
+++ b/qupulse/program/waveforms.py
@@ -360,6 +360,12 @@ class TableWaveform(Waveform):
         else:
             return TableWaveform(channel, tuple(table))
 
+    @property
+    def compare_key(self) -> Any:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._channel_id, self._table
+
     def unsafe_sample(self,
                       channel: ChannelID,
                       sample_times: np.ndarray,
@@ -440,6 +446,12 @@ class ConstantWaveform(Waveform):
 
         return {self._channel}
 
+    @property
+    def compare_key(self) -> Tuple[Any, ...]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._duration, self._amplitude, self._channel
+
     def unsafe_sample(self,
                       channel: ChannelID,
                       sample_times: np.ndarray,
@@ -507,6 +519,12 @@ class FunctionWaveform(Waveform):
     @property
     def defined_channels(self) -> AbstractSet[ChannelID]:
         return {self._channel_id}
+
+    @property
+    def compare_key(self) -> Any:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._channel_id, self._expression, self._duration
 
     @property
     def duration(self) -> TimeType:
@@ -633,6 +651,12 @@ class SequenceWaveform(Waveform):
                                       output_array=output_array[indices])
             time = end
         return output_array
+
+    @property
+    def compare_key(self) -> Tuple[Waveform]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._sequenced_waveforms
 
     @property
     def duration(self) -> TimeType:
@@ -778,6 +802,12 @@ class MultiChannelWaveform(Waveform):
     def defined_channels(self) -> AbstractSet[ChannelID]:
         return self._defined_channels
 
+    @property
+    def compare_key(self) -> Any:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._sub_waveforms
+
     def unsafe_sample(self,
                       channel: ChannelID,
                       sample_times: np.ndarray,
@@ -841,6 +871,12 @@ class RepetitionWaveform(Waveform):
                                      output_array=output_array[indices])
             time = end
         return output_array
+
+    @property
+    def compare_key(self) -> Tuple[Any, int]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._body.compare_key, self._repetition_count
 
     def unsafe_get_subset_for_channels(self, channels: AbstractSet[ChannelID]) -> Waveform:
         return RepetitionWaveform.from_repetition_count(
@@ -913,6 +949,12 @@ class TransformingWaveform(Waveform):
     def defined_channels(self) -> AbstractSet[ChannelID]:
         return self.transformation.get_output_channels(self.inner_waveform.defined_channels)
 
+    @property
+    def compare_key(self) -> Tuple[Waveform, Transformation]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self.inner_waveform, self.transformation
+
     def unsafe_get_subset_for_channels(self, channels: Set[ChannelID]) -> 'SubsetWaveform':
         return SubsetWaveform(self, channel_subset=channels)
 
@@ -957,6 +999,12 @@ class SubsetWaveform(Waveform):
     @property
     def defined_channels(self) -> FrozenSet[ChannelID]:
         return self._channel_subset
+
+    @property
+    def compare_key(self) -> Tuple[frozenset, Waveform]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self.defined_channels, self.inner_waveform
 
     def unsafe_get_subset_for_channels(self, channels: Set[ChannelID]) -> Waveform:
         return self.inner_waveform.get_subset_for_channels(channels)
@@ -1105,6 +1153,12 @@ class ArithmeticWaveform(Waveform):
         # TODO: optimization possible
         return SubsetWaveform(self, channels)
 
+    @property
+    def compare_key(self) -> Tuple[str, Waveform, Waveform]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._arithmetic_operator, self._lhs, self._rhs
+
 
 class FunctorWaveform(Waveform):
     # TODO: Use Protocol to enforce that it accepts second argument has the keyword out
@@ -1161,6 +1215,11 @@ class FunctorWaveform(Waveform):
             self._inner_waveform.unsafe_get_subset_for_channels(channels),
             {ch: self._functor[ch] for ch in channels})
 
+    @property
+    def compare_key(self) -> Tuple[Waveform, FrozenSet]:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._inner_waveform, frozenset(self._functor.items())
 
 
 class ReversedWaveform(Waveform):
@@ -1198,6 +1257,12 @@ class ReversedWaveform(Waveform):
 
     def unsafe_get_subset_for_channels(self, channels: AbstractSet[ChannelID]) -> 'Waveform':
         return ReversedWaveform.from_to_reverse(self._inner.unsafe_get_subset_for_channels(channels))
+
+    @property
+    def compare_key(self) -> Hashable:
+        warnings.warn("Waveform.compare_key is deprecated since 0.11 and will be removed in 0.12",
+                      DeprecationWarning, stacklevel=2)
+        return self._inner.compare_key
 
     def reversed(self) -> 'Waveform':
         return self._inner

--- a/qupulse/program/waveforms.py
+++ b/qupulse/program/waveforms.py
@@ -17,17 +17,14 @@ from weakref import WeakValueDictionary, ref
 import numpy as np
 
 from qupulse import ChannelID
-from qupulse.program.transformation import Transformation
-from qupulse.utils import checked_int_cast, isclose
-from qupulse.utils.types import TimeType, time_from_float
 from qupulse.utils.performance import is_monotonic
-from qupulse.comparable import Comparable
 from qupulse.expressions import ExpressionScalar
 from qupulse.pulses.interpolation import InterpolationStrategy
 from qupulse.utils import checked_int_cast, isclose
-from qupulse.utils.types import TimeType, time_from_float, FrozenDict
+from qupulse.utils.types import TimeType, time_from_float
 from qupulse.program.transformation import Transformation
 from qupulse.utils import pairwise
+
 
 class ConstantFunctionPulseTemplateWarning(UserWarning):
     """  This warning indicates a constant waveform is constructed from a FunctionPulseTemplate """

--- a/qupulse/program/waveforms.py
+++ b/qupulse/program/waveforms.py
@@ -144,12 +144,14 @@ class Waveform(metaclass=ABCMeta):
             return output_array
 
     def __hash__(self):
-        return hash(tuple(getattr(self, slot) for slot in self.__slots__))
+        if self.__class__.__base__ is not Waveform:
+            raise NotImplementedError("Waveforms __hash__ and __eq__ implementation requires direct inheritance")
+        return hash(tuple(getattr(self, slot) for slot in self.__slots__)) ^ hash(self._duration)
 
     def __eq__(self, other):
         slots = self.__slots__
         if slots is getattr(other, '__slots__', None):
-            return all(getattr(self, slot) == getattr(other, slot) for slot in slots)
+            return self._duration == other._duration and all(getattr(self, slot) == getattr(other, slot) for slot in slots)
         # The other class might be more lenient
         return NotImplemented
 

--- a/tests/_program/transformation_tests.py
+++ b/tests/_program/transformation_tests.py
@@ -64,10 +64,12 @@ class LinearTransformationTests(unittest.TestCase):
         matrix_2 = np.array([[1, 1, 1], [1, 0, -1]])
         trafo_2 = LinearTransformation(matrix_2, in_chs_2, out_chs_2)
 
-        self.assertEqual(trafo.compare_key, trafo_2.compare_key)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(trafo.compare_key, trafo_2.compare_key)
         self.assertEqual(trafo, trafo_2)
         self.assertEqual(hash(trafo), hash(trafo_2))
-        self.assertEqual(trafo.compare_key, (in_chs, out_chs, matrix.tobytes()))
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(trafo.compare_key, (in_chs, out_chs, matrix.tobytes()))
 
     def test_from_pandas(self):
         try:
@@ -175,7 +177,8 @@ class LinearTransformationTests(unittest.TestCase):
 
 class IdentityTransformationTests(unittest.TestCase):
     def test_compare_key(self):
-        self.assertIsNone(IdentityTransformation().compare_key)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsNone(IdentityTransformation().compare_key)
 
     def test_singleton(self):
         self.assertIs(IdentityTransformation(), IdentityTransformation())
@@ -216,7 +219,8 @@ class ChainedTransformationTests(unittest.TestCase):
         chained = ChainedTransformation(*trafos)
 
         self.assertEqual(chained.transformations, trafos)
-        self.assertIs(chained.transformations, chained.compare_key)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIs(chained.transformations, chained.compare_key)
 
     def test_get_output_channels(self):
         trafos = TransformationStub(), TransformationStub(), TransformationStub()

--- a/tests/comparable_tests.py
+++ b/tests/comparable_tests.py
@@ -1,7 +1,10 @@
 import unittest
 from typing import Any
+import warnings
 
-from qupulse.comparable import Comparable
+with warnings.catch_warnings():
+    warnings.simplefilter(action='ignore', category=DeprecationWarning)
+    from qupulse.comparable import Comparable
 
 class DummyComparable(Comparable):
 

--- a/tests/pulses/arithmetic_pulse_template_tests.py
+++ b/tests/pulses/arithmetic_pulse_template_tests.py
@@ -435,9 +435,11 @@ class ArithmeticPulseTemplateTest(unittest.TestCase):
         to_single_waveform = {'something_else'}
         program_builder = mock.Mock()
 
-        expected_transformation = mock.Mock(spec=IdentityTransformation())
+        with self.assertWarns(DeprecationWarning):
+            expected_transformation = mock.Mock(spec=IdentityTransformation())
 
-        inner_trafo = mock.Mock(spec=IdentityTransformation())
+        with self.assertWarns(DeprecationWarning):
+            inner_trafo = mock.Mock(spec=IdentityTransformation())
         inner_trafo.chain.return_value = expected_transformation
 
         with mock.patch.object(rhs, '_create_program') as inner_create_program:
@@ -593,7 +595,10 @@ class ArithmeticPulseTemplateTest(unittest.TestCase):
         channel_mapping = dict(a='u', b='v')
 
         inner_wf = DummyWaveform(duration=6, defined_channels={'a'})
-        trafo = mock.Mock(spec=IdentityTransformation())
+        with self.assertWarns(DeprecationWarning):
+            # mock will inspect alsod eprecated attributes
+            # TODO: remove assert as soon as attribute is removed
+            trafo = mock.Mock(spec=IdentityTransformation())
 
         arith = ArithmeticPulseTemplate(pt, '-', 6)
 

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -76,7 +76,7 @@ class SequencePulseTemplateTest(unittest.TestCase):
             self.assertIs(pt.build_waveform_calls[0][0], parameters)
 
         self.assertIsInstance(wf, SequenceWaveform)
-        for wfa, wfb in zip(wf.compare_key, wfs):
+        for wfa, wfb in zip(wf.sequenced_waveforms, wfs):
             self.assertIs(wfa, wfb)
 
     def test_identifier(self) -> None:

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -34,7 +34,6 @@ class MeasurementWindowTestCase(unittest.TestCase):
 
 
 class DummyWaveform(Waveform):
-
     def __init__(self, duration: Union[float, TimeType]=0, sample_output: Union[numpy.ndarray, dict]=None, defined_channels=None) -> None:
         super().__init__(duration=duration if isinstance(duration, TimeType) else TimeType.from_float(duration))
         self.sample_output = sample_output
@@ -45,6 +44,12 @@ class DummyWaveform(Waveform):
                 defined_channels = {'A'}
         self.defined_channels_ = defined_channels
         self.sample_calls = []
+
+    def __hash__(self):
+        return hash(self.compare_key)
+
+    def __eq__(self, other):
+        return isinstance(other, DummyWaveform) and self.compare_key == other.compare_key
 
     @property
     def compare_key(self) -> Any:


### PR DESCRIPTION
Deprecate comparable because it is "unpythonic" and makes comparisons hard to follow.

Three subclasses have been changed:

 - `AWG` now directly implements an `id` based hash and comparison.
 - `Waveform` is now compared and hashed based on the `__slots__` and `_duration` of the base class by default. `TransformingWaveform` overrides that because it caches results for more efficient multi channel sampling.
 - `Transformation` implementations now provide there own `__eq__` and `__hash__`.