### PR TITLE
Fix documentation build: Hardware notebook

### DIFF
--- a/doc/source/examples/04ZurichInstrumentsSetup.ipynb
+++ b/doc/source/examples/04ZurichInstrumentsSetup.ipynb
@@ -462,6 +462,7 @@
   }
  ],
  "metadata": {
+  "nbsphinx": { "execute": "never" },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Do not execute hardware dependent notebook when building docs