### PR TITLE
Add to_single_waveform property to PulseTemplate

### DIFF
--- a/changes.d/578.feature
+++ b/changes.d/578.feature
@@ -1,0 +1,2 @@
+Add a ``to_single_waveform`` keyword argument to ``SequencePT``, ``RepetitionPT``, ``ForLoopPT`` and ``MappingPT``.
+When ``to_single_waveform='always'`` is passed the corresponding pulse template is translated into a single waveform on program creation.

--- a/qupulse/pulses/loop_pulse_template.py
+++ b/qupulse/pulses/loop_pulse_template.py
@@ -23,7 +23,7 @@ from qupulse.program import ProgramBuilder
 from qupulse.expressions import ExpressionScalar, ExpressionVariableMissingException, Expression
 from qupulse.utils import checked_int_cast, cached_property
 from qupulse.pulses.parameters import InvalidParameterNameException, ParameterConstrainer, ParameterNotProvidedException
-from qupulse.pulses.pulse_template import PulseTemplate, ChannelID, AtomicPulseTemplate
+from qupulse.pulses.pulse_template import PulseTemplate, ChannelID, AtomicPulseTemplate, SingleWaveformStrategy
 from qupulse.program.waveforms import SequenceWaveform as ForLoopWaveform
 from qupulse.pulses.measurement import MeasurementDefiner, MeasurementDeclaration
 from qupulse.pulses.range import ParametrizedRange, RangeScope
@@ -34,8 +34,9 @@ __all__ = ['ForLoopPulseTemplate', 'LoopPulseTemplate', 'LoopIndexNotUsedExcepti
 class LoopPulseTemplate(PulseTemplate):
     """Base class for loop based pulse templates. This class is still abstract and cannot be instantiated."""
     def __init__(self, body: PulseTemplate,
-                 identifier: Optional[str]):
-        super().__init__(identifier=identifier)
+                 identifier: Optional[str],
+                 to_single_waveform: Optional[SingleWaveformStrategy] = None):
+        super().__init__(identifier=identifier, to_single_waveform=to_single_waveform)
         self.__body = body
 
     @property
@@ -68,6 +69,7 @@ class ForLoopPulseTemplate(LoopPulseTemplate, MeasurementDefiner, ParameterConst
                  *,
                  measurements: Optional[Sequence[MeasurementDeclaration]]=None,
                  parameter_constraints: Optional[Sequence]=None,
+                 to_single_waveform: Optional[SingleWaveformStrategy] = None,
                  registry: PulseRegistryType=None) -> None:
         """
         Args:
@@ -76,7 +78,7 @@ class ForLoopPulseTemplate(LoopPulseTemplate, MeasurementDefiner, ParameterConst
             loop_range: Range to loop through
             identifier: Used for serialization
         """
-        LoopPulseTemplate.__init__(self, body=body, identifier=identifier)
+        LoopPulseTemplate.__init__(self, body=body, identifier=identifier, to_single_waveform=to_single_waveform)
         MeasurementDefiner.__init__(self, measurements=measurements)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 

--- a/qupulse/pulses/mapping_pulse_template.py
+++ b/qupulse/pulses/mapping_pulse_template.py
@@ -10,7 +10,7 @@ import collections
 from qupulse.utils.types import ChannelID, FrozenDict, FrozenMapping
 from qupulse.expressions import Expression, ExpressionScalar
 from qupulse.parameter_scope import Scope, MappedScope
-from qupulse.pulses.pulse_template import PulseTemplate, MappingTuple
+from qupulse.pulses.pulse_template import PulseTemplate, MappingTuple, SingleWaveformStrategy
 from qupulse.pulses.parameters import ParameterNotProvidedException, ParameterConstrainer
 from qupulse.program.waveforms import Waveform
 from qupulse.program import ProgramBuilder
@@ -38,6 +38,7 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
                  channel_mapping: Optional[Dict[ChannelID, ChannelID]] = None,
                  parameter_constraints: Optional[List[str]]=None,
                  allow_partial_parameter_mapping: bool = None,
+                 to_single_waveform: Optional[SingleWaveformStrategy]=None,
                  registry: PulseRegistryType=None) -> None:
         """Standard constructor for the MappingPulseTemplate.
 
@@ -56,7 +57,7 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
         :param parameter_constraints:
         :param allow_partial_parameter_mapping: If None the value of the class variable ALLOW_PARTIAL_PARAMETER_MAPPING
         """
-        PulseTemplate.__init__(self, identifier=identifier)
+        PulseTemplate.__init__(self, identifier=identifier, to_single_waveform=to_single_waveform)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
         if allow_partial_parameter_mapping is None:

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -35,7 +35,7 @@ from qupulse.parameter_scope import Scope, DictScope
 from qupulse.program import ProgramBuilder, default_program_builder, Program
 
 __all__ = ["PulseTemplate", "AtomicPulseTemplate", "DoubleParameterNameException", "MappingTuple",
-           "UnknownVolatileParameter"]
+           "UnknownVolatileParameter", "SingleWaveformStrategy"]
 
 
 MappingTuple = Union[Tuple['PulseTemplate'],

--- a/qupulse/pulses/repetition_pulse_template.py
+++ b/qupulse/pulses/repetition_pulse_template.py
@@ -19,7 +19,7 @@ from qupulse.parameter_scope import Scope
 from qupulse.utils.types import ChannelID
 from qupulse.expressions import ExpressionScalar
 from qupulse.utils import checked_int_cast
-from qupulse.pulses.pulse_template import PulseTemplate
+from qupulse.pulses.pulse_template import PulseTemplate, SingleWaveformStrategy
 from qupulse.pulses.loop_pulse_template import LoopPulseTemplate
 from qupulse.pulses.parameters import ParameterConstrainer
 from qupulse.pulses.measurement import MeasurementDefiner, MeasurementDeclaration
@@ -44,6 +44,7 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
                  *args,
                  parameter_constraints: Optional[List]=None,
                  measurements: Optional[List[MeasurementDeclaration]]=None,
+                 to_single_waveform: Optional[SingleWaveformStrategy] = None,
                  registry: PulseRegistryType=None
                  ) -> None:
         """Create a new RepetitionPulseTemplate instance.
@@ -59,7 +60,7 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
         elif args:
             TypeError('RepetitionPulseTemplate expects 3 positional arguments, got ' + str(3 + len(args)))
 
-        LoopPulseTemplate.__init__(self, identifier=identifier, body=body)
+        LoopPulseTemplate.__init__(self, identifier=identifier, body=body, to_single_waveform=to_single_waveform)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
         MeasurementDefiner.__init__(self, measurements=measurements)
 

--- a/qupulse/pulses/sequence_pulse_template.py
+++ b/qupulse/pulses/sequence_pulse_template.py
@@ -16,7 +16,7 @@ from qupulse.program import ProgramBuilder
 from qupulse.parameter_scope import Scope
 from qupulse.utils import cached_property
 from qupulse.utils.types import MeasurementWindow, ChannelID, TimeType
-from qupulse.pulses.pulse_template import PulseTemplate, AtomicPulseTemplate
+from qupulse.pulses.pulse_template import PulseTemplate, AtomicPulseTemplate, SingleWaveformStrategy
 from qupulse.pulses.parameters import ConstraintLike, ParameterConstrainer
 from qupulse.pulses.mapping_pulse_template import MappingPulseTemplate, MappingTuple
 from qupulse.program.waveforms import SequenceWaveform
@@ -44,6 +44,7 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
                  identifier: Optional[str]=None,
                  parameter_constraints: Optional[Iterable[ConstraintLike]]=None,
                  measurements: Optional[List[MeasurementDeclaration]]=None,
+                 to_single_waveform: Optional[SingleWaveformStrategy]=None,
                  registry: PulseRegistryType=None) -> None:
         """Create a new SequencePulseTemplate instance.
 
@@ -64,7 +65,7 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
                 SequencePulseTemplate as tuples of the form (PulseTemplate, Dict(str -> str)).
             identifier (str): A unique identifier for use in serialization. (optional)
         """
-        PulseTemplate.__init__(self, identifier=identifier)
+        PulseTemplate.__init__(self, identifier=identifier, to_single_waveform=to_single_waveform)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
         MeasurementDefiner.__init__(self, measurements=measurements)
 

--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -11,6 +11,7 @@ from qupulse.pulses.parameters import InvalidParameterNameException, ParameterCo
     ParameterNotProvidedException, ParameterConstraint
 
 from qupulse.program.loop import LoopBuilder, Loop
+from qupulse.program.waveforms import SequenceWaveform
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, MeasurementWindowTestCase, DummyWaveform
 from tests.serialization_dummies import DummySerializer
@@ -425,6 +426,15 @@ class ForLoopTemplateSequencingTests(MeasurementWindowTestCase):
 
         # not ensure same result as from Sequencer here - we're testing appending to an already existing parent loop
         # which is a use case that does not immediately arise from using Sequencer
+
+    def test_single_waveform(self):
+        inner_wf = DummyWaveform()
+        inner_pt = DummyPulseTemplate(waveform=inner_wf, parameter_names={'idx'})
+
+        flpt = ForLoopPulseTemplate(inner_pt, loop_index='idx', loop_range=3, to_single_waveform='always')
+        program = flpt.create_program()
+        expected = Loop(children=[Loop(repetition_count=1, waveform=SequenceWaveform.from_sequence([inner_wf] * 3))])
+        self.assertEqual(expected, program)
 
 
 class ForLoopPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):

--- a/tests/pulses/mapping_pulse_template_tests.py
+++ b/tests/pulses/mapping_pulse_template_tests.py
@@ -428,6 +428,15 @@ class MappingPulseTemplateSequencingTest(MeasurementWindowTestCase):
         with self.assertRaisesRegex(ValueError, 'multiple channels to the same target'):
             MappingPulseTemplate(dpt, channel_mapping={'A': 'X', 'B': 'X'})
 
+    def test_single_waveform(self):
+        inner_wf = DummyWaveform()
+        inner_pt = DummyPulseTemplate(waveform=inner_wf)
+
+        mpt = MappingPulseTemplate(inner_pt, to_single_waveform='always')
+        program = mpt.create_program()
+        expected = Loop(children=[Loop(repetition_count=1, waveform=inner_wf)])
+        self.assertEqual(expected, program)
+
 
 class PulseTemplateParameterMappingExceptionsTests(unittest.TestCase):
 

--- a/tests/pulses/repetition_pulse_template_tests.py
+++ b/tests/pulses/repetition_pulse_template_tests.py
@@ -3,6 +3,7 @@ import warnings
 from unittest import mock
 
 from qupulse.parameter_scope import Scope, DictScope
+from qupulse.program.waveforms import RepetitionWaveform
 from qupulse.utils.types import FrozenDict
 
 from qupulse.program import default_program_builder
@@ -569,6 +570,15 @@ class RepetitionPulseTemplateSequencingTests(MeasurementWindowTestCase):
                                    global_transformation=None,
                                    program_builder=program_builder)
         self.assertIsNone(program_builder.to_program())
+
+    def test_single_waveform(self):
+        inner_wf = DummyWaveform()
+        inner_pt = DummyPulseTemplate(waveform=inner_wf)
+
+        rpt = RepetitionPulseTemplate(inner_pt, repetition_count=42, to_single_waveform='always')
+        program = rpt.create_program()
+        expected = Loop(children=[Loop(repetition_count=1, waveform=RepetitionWaveform.from_repetition_count(inner_wf, 42))])
+        self.assertEqual(expected, program)
 
 
 class RepetitionPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -79,6 +79,15 @@ class SequencePulseTemplateTest(unittest.TestCase):
         for wfa, wfb in zip(wf.sequenced_waveforms, wfs):
             self.assertIs(wfa, wfb)
 
+    def test_single_waveform(self):
+        wfs = [DummyWaveform(), DummyWaveform()]
+        pts = [DummyPulseTemplate(waveform=wf) for wf in wfs]
+
+        spt = SequencePulseTemplate(*pts, to_single_waveform='always')
+        program = spt.create_program()
+        expected = Loop(children=[Loop(repetition_count=1, waveform=SequenceWaveform.from_sequence(wfs))])
+        self.assertEqual(expected, program)
+
     def test_identifier(self) -> None:
         identifier = 'some name'
         pulse = SequencePulseTemplate(DummyPulseTemplate(), identifier=identifier)


### PR DESCRIPTION
This PR adds a `to_single_waveform` argument to `PulseTemplate` which makes it translate itself into a single waveform on program creation.

Furthermore these pulse templates for ward the kwarg:
 - `SequencePT`
 - `RepetitionPT`
 - `ForLoopPT`.
 - `MappingPT`

Closes #578 
Enables #882 

 - [x] Add kwarg to other pulse templates
 - [x] write test
 - [x] newspiece

Documentation is moved to #894 