### PR TITLE
Add more sophisticated padding support and helper functions for that

### DIFF
--- a/changes.d/882.feature
+++ b/changes.d/882.feature
@@ -1,0 +1,1 @@
+Add functions ``PulseTemplate.pad_selected_subtemplates_to`` for padding inner templates and ``PulseTemplate.with_mapped_subtemplates`` as implementation helper.

--- a/changes.d/882.removal
+++ b/changes.d/882.removal
@@ -1,0 +1,1 @@
+The ``pt_kwargs`` keyword argument of ``PulseTemplate.pad_to`` is now deprecated and was replaced by the ``spt_kwargs`` argument which no longer enforces sequence pulse template creation even if no padding is required.

--- a/doc/source/concepts/pulsetemplates.rst
+++ b/doc/source/concepts/pulsetemplates.rst
@@ -75,6 +75,8 @@ In addition to the fundamental concepts and subclassing structure, :class:`.Puls
 
   - :meth:`.PulseTemplate.pad_to` extends the duration of a pulse template to a desired length, automatically appending
     a constant pulse segment that matches the final output values.
+  - :meth:`.PulseTemplate.pad_selected_subtemplates_to` extends the duration selected subtemplates to a desired length, automatically appending
+    a constant pulse segment that matches the final output values. By default it pads all atomic subtemplates.
 
 - **Properties**:
 
@@ -89,6 +91,10 @@ In addition to the fundamental concepts and subclassing structure, :class:`.Puls
     scaling of pulses.
   - The :meth:`@` operator (matrix multiplication) is repurposed to represent time-wise concatenation of pulses (see
     :meth:`.SequencePulseTemplate.concatenate`).
+
+- **Utility**:
+
+ - :meth:`.PulseTemplate.with_mapped_subtemplates` allows mapping some or all subtemplates with a configurable recursion strategy. It is used to implement :meth:`.PulseTemplate.pad_selected_subtemplates_to`.
 
 These convenience features allow for more compact, readable, and flexible pulse definitions, helping to focus on the
 overall structure of the experiment.

--- a/qupulse/pulses/pulse_template.py
+++ b/qupulse/pulses/pulse_template.py
@@ -500,6 +500,9 @@ class PulseTemplate(Serializable):
         """Pad all subtemplates for which the selector returns true with the given padding strategy. If no selector is
         specified, all atomic subtemplates are padded. Padding non-atomic pulse templates is generally non-sensical when the subtemplates are padded.
 
+        By default newly created `SequencePT`s have the metadata field `to_single_waveform` set to "always".
+        Overwrite pt_kwargs to supply other metadata arguments.
+
         If you need more customization you can use :py:`.PulseTemlate.with_mapped_subtemplates`.
 
         Args:
@@ -512,6 +515,9 @@ class PulseTemplate(Serializable):
         """
         if selector is None:
             selector = PulseTemplate._is_atomic
+
+        if pt_kwargs is None:
+            pt_kwargs = {"metadata": {"to_single_waveform": "always"}}
 
         if selector(self):
             return self.pad_to(to_new_duration, pt_kwargs)

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -439,6 +439,9 @@ class PulseTemplateTest(unittest.TestCase):
         self.assertIsInstance(padded, SequencePT)
         self.assertIs(padded.subtemplates[0], pt)
 
+    def test_pad_selected_subtemplates(self):
+        raise NotImplementedError()
+
     @mock.patch('qupulse.pulses.pulse_template.default_program_builder')
     def test_create_program_none(self, pb_mock) -> None:
         template = PulseTemplateStub(defined_channels={'A'}, parameter_names={'foo'})
@@ -541,6 +544,9 @@ class WithMethodTests(unittest.TestCase):
         expected = AtomicMultiChannelPT(self.fpt, self.cpt)
         actual = self.fpt.with_parallel_atomic(self.cpt)
         self.assertEqual(expected, actual)
+
+    def test_mapped_subtemplates(self):
+        raise NotImplementedError()
 
 
 class AtomicPulseTemplateTests(unittest.TestCase):

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -373,8 +373,6 @@ class PulseTemplateTest(unittest.TestCase):
         _internal_create_program.assert_called_once_with(**expected_internal_kwargs, program_builder=program_builder)
 
     def test_pad_to(self):
-        from qupulse.pulses import SequencePT
-
         def to_multiple_of_192(x: Expression) -> Expression:
             return (x + 191) // 192 * 192
 
@@ -588,8 +586,8 @@ class WithMethodTests(unittest.TestCase):
         self.assertEqual(expected_pre, actual_pre)
 
         # POST
-        expected_post = SequencePT(self.fpt.renamed('fpt_mapped'),
-                                  RepetitionPT(self.fpt.renamed('fpt_mapped'), 2, identifier='rpt_mapped'),
+        expected_post = SequencePT(self.fpt.renamed('fpt'),
+                                  RepetitionPT(self.fpt.renamed('fpt'), 2, identifier='rpt_mapped'),
                                   identifier='spt_mapped')
         expected_calls_post = [
             self.cpt,

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -602,8 +602,9 @@ class WithMethodTests(unittest.TestCase):
         self.assertEqual(expected_post, actual_post)
         calls.clear()
 
-        expected_self = SequencePT(self.fpt, self.fpt, identifier='spt_mapped')
-        actual_self = self.spt.with_mapped_subtemplates(map_fn=lambda x: self.fpt, recursion_strategy='self', identifier_map=identifier_map)
+        inner = RepetitionPT(self.fpt, 2, identifier='new_rpt')
+        expected_self = SequencePT(inner, inner, identifier='spt_mapped')
+        actual_self = self.spt.with_mapped_subtemplates(map_fn=lambda x: inner, recursion_strategy='self', identifier_map=identifier_map)
         self.assertEqual(expected_self, actual_self)
 
 


### PR DESCRIPTION
A qupulsy replacement for https://github.com/qutech/qupulse/blob/feat/linspace_measurements_reversed_registers_divisor/qupulse/pulses/pulse_template.py#L637

Implements #882 

TODO:
 - [x] rest of documentation
 - [x] test
 - [x] newspiece
 - [x] handle identifier and registry