### PR TITLE
Replace dedicated PulseTemplate.to_single_waveform property with a metadata class

### DIFF
--- a/qupulse/utils/types.py
+++ b/qupulse/utils/types.py
@@ -11,6 +11,7 @@ import functools
 import warnings
 import collections
 import operator
+import difflib
 
 import numpy
 import sympy
@@ -438,3 +439,110 @@ class SequenceProxy(collections.abc.Sequence):
                     and all(x == y for x, y in zip(self, other)))
         else:
             return NotImplemented
+
+
+class MetaDataWarning(UserWarning):
+    """This warning is raised when there is an inconsistency with a field and the field declaration."""
+
+
+def _is_similar(x: str, y: str) -> bool:
+    return difflib.SequenceMatcher(None, x, y).quick_ratio() > 0.6
+
+
+class MetaData:
+    _DECLARED_FIELDS = {}
+
+    def __init__(self, **kwargs):
+        """A class that allows to define meta data fields as simple attributes on instances of this class.
+
+        You can declare user data fields by calling the classmethod :meth:`declare_user_data`. Setting a non-declared
+        field or setting a declared field with the wrong type will raise a UserDataWarning warning.
+
+        User data is mutable!
+
+        Args:
+            **kwargs:
+        """
+        super().__init__()
+
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+        for name, (_, factory) in self._DECLARED_FIELDS.values():
+            if not factory or name in kwargs:
+                continue
+            setattr(self, name, factory())
+
+
+    @classmethod
+    def declare_field(cls, name: str, data_type: typing.Union[type, typing.AbstractSet], default_factory: typing.Optional[callable] = None):
+        """Declare a user data field."""
+        if name in cls._DECLARED_FIELDS:
+            if (data_type, default_factory) != cls._DECLARED_FIELDS[name]:
+                warnings.warn(
+                    f"Field {name} already declared for class {cls} with different type or default factory. "
+                    f"Overwriting with {data_type} and {default_factory}.",
+                    category=MetaDataWarning,
+                    stacklevel=2
+                )
+        cls._DECLARED_FIELDS[name] = (data_type, default_factory)
+
+    def get_serialization_data(self) -> typing.Dict[str, typing.Any]:
+        return self.__dict__.copy()
+
+    def __setattr__(self, key, value):
+        msg = []
+
+        if key in self._DECLARED_FIELDS:
+            dtype, _ = self._DECLARED_FIELDS[key]
+            if isinstance(dtype, (type, tuple)):
+                if not isinstance(value, dtype):
+                    msg.append(f"Expected {key!r} to be of type {dtype} but got {type(value)}")
+            elif isinstance(dtype, typing.AbstractSet):
+                if value not in dtype:
+                    msg.append(f"Expected {key!r} to be one of {dtype!r} but got {value!r}")
+        elif not hasattr(self, key):
+            msg.append(f"The field {key!r} is not declared.")
+
+            similar = []
+            for name in self._DECLARED_FIELDS:
+                if _is_similar(name, key):
+                    similar.append(name)
+
+            if similar:
+                msg.append(f"Did you mean to use one of the following name(s): {similar!r} instead?")
+
+        if msg:
+            stacklevel = 2
+            try:
+                # we increase the stacklevel if the call comes from our own __init__
+                stacklevel += inspect.stack(context=0)[1].frame.f_locals.get("self", None) is self
+            except Exception:
+                pass
+            warnings.warn(" ".join(msg), category=MetaDataWarning, stacklevel=stacklevel)
+        super().__setattr__(key, value)
+
+    def __getattr__(self, item):
+        """We implement __getattr__ for more helpful error messages."""
+
+        msg = [f"This instance of {type(self).__name__} has no attribute {item!r}"]
+
+        if item in self._DECLARED_FIELDS:
+            msg.append("It is however a declared field")
+
+        else:
+            similar_declared = []
+            for name in self._DECLARED_FIELDS:
+                if _is_similar(item, name):
+                    similar_declared.append(name)
+
+            if similar_declared:
+                msg.append(f"It is however similar to the declared field(s) {similar_declared!r}")
+        raise AttributeError(". ".join(msg))
+
+    def __bool__(self):
+        return bool(self.__dict__)
+
+    def __repr__(self):
+        items = (f"{k}={v!r}" for k, v in self.__dict__.items())
+        return "{}({})".format(type(self).__name__, ", ".join(items))


### PR DESCRIPTION
The metadataclass is intended to track non-pulsy information like translation hints or tags than can be consumed further down the line.

I spend to much time writing a half-baked field declaration in an attempt to unify flexibility, IDE hints and useful error messages.