### PR TITLE
pad expression brackets

### DIFF
--- a/qupulse/utils/__init__.py
+++ b/qupulse/utils/__init__.py
@@ -152,5 +152,5 @@ def to_next_multiple(sample_rate: ExpressionLike, quantum: int,
         return lambda duration: -(-(duration*sample_rate)//quantum) * (quantum/sample_rate)
     else:
         #still return 0 if duration==0
-        return lambda duration: ExpressionScalar(f'{quantum}/({sample_rate})*Max({min_quanta},-(-{duration}*{sample_rate}//{quantum}))*Max(0, sign({duration}))')
+        return lambda duration: ExpressionScalar(f'{quantum}/({sample_rate})*Max({min_quanta},-(-({duration})*{sample_rate}//{quantum}))*Max(0, sign({duration}))')
    

--- a/tests/utils/utils_tests.py
+++ b/tests/utils/utils_tests.py
@@ -140,4 +140,11 @@ class ToNextMultipleTests(unittest.TestCase):
         expected = 16.
         self.assertEqual(evaluated, expected)
         
+        #bracket silent bug
+        duration = ExpressionScalar('51 + q*51')
+        evaluated = to_next_multiple(sample_rate=1.0,quantum=16,min_quanta=1)(duration).evaluate_in_scope(
+                        dict(q=3.14159,))
+        expected = 224.
+        self.assertEqual(evaluated, expected)
+        
         


### PR DESCRIPTION
ExpressionScalars seem to omit brackets even if supplied in their definition; `to_next_multiple ` therefore could fail