### PR TITLE
Refactor context management for program builders

### DIFF
--- a/changes.d/933.feature
+++ b/changes.d/933.feature
@@ -1,0 +1,1 @@
+Replace PulseTemplate._create_program(**a_lot_of__kwargs) with PulseTemplate._build_program(program_builder).

--- a/qupulse/hardware/awgs/base.py
+++ b/qupulse/hardware/awgs/base.py
@@ -20,7 +20,7 @@ import warnings
 
 from qupulse.hardware.util import get_sample_times, not_none_indices
 from qupulse.utils.types import ChannelID
-from qupulse.program.linspace import LinSpaceNode, LinSpaceTopLevel, Play, \
+from qupulse.program.linspace import LinSpaceNode, LinSpaceProgram, Play, \
     transform_linspace_commands, to_increment_commands
 from qupulse.program.loop import Loop
 from qupulse.program.waveforms import Waveform
@@ -178,7 +178,7 @@ class ProgramOverwriteException(Exception):
 
 
 #!!! typehint obsolete
-AllowedProgramTypes = Union[Loop,LinSpaceTopLevel,]
+AllowedProgramTypes = Union[Loop,LinSpaceProgram,]
 
 
 class ChannelTransformation(NamedTuple):

--- a/qupulse/program/linspace.py
+++ b/qupulse/program/linspace.py
@@ -273,7 +273,7 @@ class LinSpaceBuilder(BaseProgramBuilder):
 
     @contextlib.contextmanager
     def with_sequence(self,
-                      measurements: Optional[Sequence[MeasurementWindow]] = None) -> ContextManager['ProgramBuilder']:
+                      measurements: Optional[Sequence[MeasurementWindow]] = None) -> Iterable['ProgramBuilder']:
         yield self
 
     def new_subprogram(self, global_transformation: 'Transformation' = None) -> ContextManager['ProgramBuilder']:
@@ -294,7 +294,7 @@ class LinSpaceBuilder(BaseProgramBuilder):
             self._stack[-1].append(LinSpaceIter(body=tuple(cmds), length=len(rng)))
 
     @contextlib.contextmanager
-    def time_reversed(self) -> ContextManager['LinSpaceBuilder']:
+    def time_reversed(self) -> Iterable['LinSpaceBuilder']:
         self._stack.append([])
         yield self
         inner = self._stack.pop()

--- a/qupulse/program/linspace.py
+++ b/qupulse/program/linspace.py
@@ -13,14 +13,15 @@ import copy
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from typing import Mapping, Optional, Sequence, ContextManager, Iterable, Tuple, \
-    Union, Dict, List, Set, ClassVar, Callable, Any
+    Union, Dict, List, Set, ClassVar, Callable, Any, AbstractSet
 from collections import OrderedDict
 
 from qupulse import ChannelID, MeasurementWindow
 from qupulse.parameter_scope import Scope, MappedScope, FrozenDict
-from qupulse.program.protocol import (ProgramBuilder, Waveform, )
+from qupulse.program.protocol import (ProgramBuilder, Waveform, BaseProgramBuilder, Program, )
 from qupulse.program.values import RepetitionCount, HardwareTime, HardwareVoltage, DynamicLinearValue, TimeType
 from qupulse.program.volatile import VolatileRepetitionCount, InefficientVolatility
+from qupulse.program.waveforms import TransformingWaveform
 
 # this resolution is used to unify increments
 # the increments themselves remain floats
@@ -173,7 +174,7 @@ class LinSpaceIter(LinSpaceNode):
         return reversed_iter
 
 
-class LinSpaceBuilder(ProgramBuilder):
+class LinSpaceBuilder(BaseProgramBuilder):
     """This program builder supports efficient translation of pulse templates that use symbolic linearly
     spaced voltages and durations.
 
@@ -208,7 +209,7 @@ class LinSpaceBuilder(ProgramBuilder):
     def _get_ranges(self):
         return dict(self._ranges)
 
-    def hold_voltage(self, duration: HardwareTime, voltages: Mapping[ChannelID, HardwareVoltage]):
+    def _transformed_hold_voltage(self, duration: HardwareTime, voltages: Mapping[ChannelID, HardwareVoltage]):
         voltages = sorted((self._name_to_idx[ch_name], value) for ch_name, value in voltages.items())
         voltages = [value for _, value in voltages]
 
@@ -249,7 +250,7 @@ class LinSpaceBuilder(ProgramBuilder):
 
         self._stack[-1].append(set_cmd)
 
-    def play_arbitrary_waveform(self, waveform: Waveform):
+    def _transformed_play_arbitrary_waveform(self, waveform: Waveform):
         return self._stack[-1].append(LinSpaceArbitraryWaveform(waveform, self._idx_to_name))
 
     def measure(self, measurements: Optional[Sequence[MeasurementWindow]]):
@@ -284,7 +285,9 @@ class LinSpaceBuilder(ProgramBuilder):
             return
         self._stack.append([])
         self._ranges.append((index_name, rng))
-        yield self
+        scope = self.build_context.scope.overwrite({index_name: DynamicLinearValue(base=0, factors={index_name: 1})})
+        with self._with_patched_context(scope=scope):
+            yield self
         cmds = self._stack.pop()
         self._ranges.pop()
         if cmds:
@@ -298,14 +301,14 @@ class LinSpaceBuilder(ProgramBuilder):
         offset = len(self._ranges)
         self._stack[-1].extend(node.reversed(offset, []) for node in reversed(inner))
 
-    def to_program(self, defined_channels: set[ChannelID]) -> Optional['LinSpaceTopLevel']:
-        if self._root():
-            return LinSpaceTopLevel(body=tuple(self._root()),
-                                    _defined_channels=defined_channels)
-        #TODO: the argument defined_channels currently does not do anything,
-        #it is included for convenience for the HDAWGLinspaceBuilder
-        #The extra class for the top level is to shift program specific functionality
-        #from awg/base to the respective program files.
+    def to_program(self) -> Optional['LinSpaceProgram']:
+        if root := self._root():
+            return LinSpaceProgram(
+                root=tuple(root),
+                defined_channels=self._idx_to_name,
+            )
+        else:
+            return None
 
 
 @dataclass
@@ -510,10 +513,10 @@ class _TranslationState:
             raise TypeError("The node type is not handled", type(node), node)
 
 
-def to_increment_commands(linspace_nodes: 'LinSpaceTopLevel') -> List[Command]:
+def to_increment_commands(linspace_nodes: 'LinSpaceProgram') -> List[Command]:
     """translate the given linspace node tree to a minimal sequence of set and increment commands as well as loops."""
     state = _TranslationState()
-    state.add_node(linspace_nodes.body)
+    state.add_node(linspace_nodes.root)
     return state.commands
 
 
@@ -550,20 +553,23 @@ def _get_waveforms_dict(transformed_commands: Sequence[Command]) -> Mapping[Wave
 
 
 @dataclass
-class LinSpaceTopLevel(LinSpaceNode):
-    
-    body: Tuple[LinSpaceNode, ...]
-    _defined_channels: set[ChannelID]
+class LinSpaceProgram(Program):
+    root: Tuple[LinSpaceNode, ...]
+    defined_channels: Tuple[ChannelID, ...]
+
+    @property
+    def duration(self) -> TimeType:
+        raise NotImplementedError("TODO")
+
+    def get_defined_channels(self) -> AbstractSet[ChannelID]:
+        return set(self.defined_channels)
     
     def dependencies(self):
         dependencies = {}
-        for node in self.body:
+        for node in self.root:
             for idx, deps in node.dependencies().items():
                 dependencies.setdefault(idx, set()).update(deps)
         return dependencies
-    
-    def get_defined_channels(self) -> set[ChannelID]:
-        return self._defined_channels
     
     def get_waveforms_dict(self,
                            channels: Sequence[ChannelID], #!!! this argument currently does not do anything.

--- a/qupulse/program/loop.py
+++ b/qupulse/program/loop.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from typing import Set, Union, Iterable, Optional, Sequence, Tuple, List, \
-    Generator, Mapping, cast, Dict, ContextManager, Any, AbstractSet
+    Generator, Mapping, cast, Dict, ContextManager, Any, AbstractSet, Iterator
 
 import numpy as np
 
@@ -832,7 +832,7 @@ class LoopBuilder(BaseProgramBuilder):
             self._build_context_stack.pop()
 
     @contextmanager
-    def time_reversed(self):
+    def time_reversed(self) -> Iterator[ProgramBuilder]:
         inner_builder = LoopBuilder(self.build_context, self.build_settings)
         yield inner_builder
         inner_program = inner_builder.to_program()
@@ -842,7 +842,7 @@ class LoopBuilder(BaseProgramBuilder):
             self._try_append(inner_program, None)
 
     @contextmanager
-    def with_sequence(self, measurements: Optional[Sequence[MeasurementWindow]] = None):
+    def with_sequence(self, measurements: Optional[Sequence[MeasurementWindow]] = None) -> Iterator[ProgramBuilder]:
         top_frame = StackFrame(LoopGuard(self._top, measurements), None)
         self._push(top_frame)
         yield self
@@ -855,7 +855,7 @@ class LoopBuilder(BaseProgramBuilder):
         self._top.append_child(waveform=waveform)
 
     @contextmanager
-    def new_subprogram(self, global_transformation: Transformation = None):
+    def new_subprogram(self, global_transformation: Transformation = None) -> Iterator[ProgramBuilder]:
         inner_builder = LoopBuilder(self.build_context, self.build_settings)
         yield inner_builder
         inner_program = inner_builder.to_program()

--- a/qupulse/program/protocol.py
+++ b/qupulse/program/protocol.py
@@ -1,15 +1,20 @@
 """Definition of the program builder protocol."""
-
-from abc import abstractmethod
-from typing import runtime_checkable, Protocol, Mapping, Optional, Sequence, Iterable, ContextManager
+import copy
+import dataclasses
+from abc import abstractmethod, ABC
+from contextlib import contextmanager
+from typing import runtime_checkable, Protocol, Mapping, Optional, Sequence, Iterable, ContextManager, AbstractSet, \
+    Union
 
 from qupulse import MeasurementWindow
-from qupulse.parameter_scope import Scope
-from qupulse.program.waveforms import Waveform
-from qupulse.program.transformation import Transformation
+from qupulse.expressions import Expression
+from qupulse.parameter_scope import Scope, MappedScope
+from qupulse.program.waveforms import Waveform, ConstantWaveform, TransformingWaveform
+from qupulse.program.transformation import Transformation, chain_transformations
 from qupulse.program.values import RepetitionCount, HardwareTime, HardwareVoltage
+from qupulse.pulses.metadata import TemplateMetadata
 
-from qupulse.utils.types import TimeType
+from qupulse.utils.types import TimeType, ChannelID
 
 
 @runtime_checkable
@@ -21,6 +26,42 @@ class Program(Protocol):
     @abstractmethod
     def duration(self) -> TimeType:
         """The duration of the program in nanoseconds."""
+
+    @abstractmethod
+    def get_defined_channels(self) -> AbstractSet[ChannelID]:
+        """Get the set of channels that are used in this program."""
+
+
+@dataclasses.dataclass
+class BuildContext:
+    scope: Scope = None
+    measurement_mapping: Mapping[str, Optional[str]] = None
+    channel_mapping: Mapping[ChannelID, Optional[ChannelID]] = None
+    transformation: Optional[Transformation] = None
+    minimal_sample_rate: Optional[TimeType] = None
+
+    def apply_mappings(self,
+                       parameter_mapping: Mapping[str, Expression] = None,
+                       measurement_mapping: Mapping[str, Optional[str]] = None,
+                       channel_mapping: Mapping[ChannelID, Optional[ChannelID]] = None,
+                       ) -> "BuildContext":
+        scope = self.scope
+        if parameter_mapping is not None:
+            scope = MappedScope(scope=scope, mapping=parameter_mapping)
+        mapped_measurement_mapping = self.measurement_mapping
+        if measurement_mapping is not None:
+            # bruh
+            mapped_measurement_mapping = {k: mapped_measurement_mapping[v] for k, v in measurement_mapping.items()}
+        mapped_channel_mapping = self.channel_mapping
+        if channel_mapping is not None:
+            mapped_channel_mapping = {inner_ch: None if outer_ch is None else mapped_channel_mapping[outer_ch]
+                                      for inner_ch, outer_ch in channel_mapping.items()}
+        return BuildContext(scope=scope, measurement_mapping=mapped_measurement_mapping, channel_mapping=mapped_channel_mapping, transformation=self.transformation, minimal_sample_rate=self.minimal_sample_rate)
+
+
+@dataclasses.dataclass
+class BuildSettings:
+    to_single_waveform: AbstractSet[str | object]
 
 
 @runtime_checkable
@@ -41,18 +82,47 @@ class ProgramBuilder(Protocol):
     and repetition implementation.
     """
 
+    @property
     @abstractmethod
-    def inner_scope(self, scope: Scope) -> Scope:
-        """This function is part of the iteration protocol and necessary to inject program builder specific parameter
-        implementations into the build process. :py:meth:`.ProgramBuilder.with_iteration` and
-        `.ProgramBuilder.with_iteration` callers *must* call this function inside the iteration.
+    def build_context(self) -> BuildContext:
+        """Get the current build context."""
+
+    @property
+    @abstractmethod
+    def build_settings(self) -> BuildSettings:
+        """Get the current build settings"""
+
+    @abstractmethod
+    def override(self,
+                 scope: Scope = None,
+                 measurement_mapping: Optional[Mapping[str, Optional[str]]] = None,
+                 channel_mapping: Optional[Mapping[ChannelID, Optional[ChannelID]]] = None,
+                 global_transformation: Optional[Transformation] = None,
+                 to_single_waveform: AbstractSet[str | object] = None,):
+        """Override the non-None values in context and settings"""
+
+
+    @abstractmethod
+    def with_mappings(self, *,
+                      parameter_mapping: Mapping[str, Expression],
+                      measurement_mapping: Mapping[str, Optional[str]],
+                      channel_mapping: Mapping[ChannelID, Optional[ChannelID]],
+                      ) -> ContextManager['ProgramBuilder']:
+        """Modify the build context for the duration of the context manager.
 
         Args:
-            scope: The parameter scope outside the iteration.
-
-        Returns:
-            The parameter scope inside the iteration.
+            parameter_mapping: A mapping of parameter names to expressions.
+            measurement_mapping: A mapping of measurement names to measurement names or None.
+            channel_mapping: A mapping of channel IDs to channel IDs or None.
         """
+
+    @abstractmethod
+    def with_transformation(self, transformation: Transformation) -> ContextManager['ProgramBuilder']:
+        """Modify the build context for the duration of the context manager."""
+
+    @abstractmethod
+    def with_metadata(self, metadata: TemplateMetadata) -> ContextManager['ProgramBuilder']:
+        """Modify the build context for the duration of the context manager."""
 
     @abstractmethod
     def hold_voltage(self, duration: HardwareTime, voltages: Mapping[str, HardwareVoltage]):
@@ -115,12 +185,9 @@ class ProgramBuilder(Protocol):
         """
 
     @abstractmethod
-    def new_subprogram(self, global_transformation: 'Transformation' = None) -> ContextManager['ProgramBuilder']:
+    def new_subprogram(self) -> ContextManager['ProgramBuilder']:
         """Create a context managed program builder whose contents are translated into a single waveform upon exit if
         it is not empty.
-
-        Args:
-            global_transformation: This transformation is applied to the waveform
 
         Returns:
             A context manager that returns a :py:class:`ProgramBuilder` on entering.
@@ -153,3 +220,110 @@ class ProgramBuilder(Protocol):
         Returns:
             A program implementation. None if nothing was added to this program builder.
         """
+
+
+class BaseProgramBuilder(ProgramBuilder, ABC):
+    def __init__(self, initial_context: BuildContext = None, initial_settings: BuildSettings = None):
+        self._build_context_stack: list[BuildContext] = [BuildContext() if initial_context is None else initial_context]
+        self._build_settings_stack: list[BuildSettings] = [BuildSettings(set()) if initial_settings is None else initial_settings]
+
+    @property
+    def build_context(self) -> BuildContext:
+        return self._build_context_stack[-1]
+
+    @property
+    def build_settings(self) -> BuildSettings:
+        return self._build_settings_stack[-1]
+
+    def override(self,
+                 scope: Scope = None,
+                 measurement_mapping: Optional[Mapping[str, Optional[str]]] = None,
+                 channel_mapping: Optional[Mapping[ChannelID, Optional[ChannelID]]] = None,
+                 global_transformation: Optional[Transformation] = None,
+                 to_single_waveform: AbstractSet[Union[str, 'PulseTemplate']] = None):
+        old_context = self._build_context_stack[-1]
+        context = BuildContext(
+            scope=old_context.scope if scope is None else scope,
+            measurement_mapping=old_context.measurement_mapping if measurement_mapping is None else measurement_mapping,
+            channel_mapping=old_context.channel_mapping if channel_mapping is None else channel_mapping,
+            transformation=old_context.transformation if global_transformation is None else global_transformation,
+        )
+        old_settings = self._build_settings_stack[-1]
+        settings = BuildSettings(
+            to_single_waveform=old_settings.to_single_waveform if to_single_waveform is None else to_single_waveform,
+        )
+
+        self._build_context_stack.append(context)
+        self._build_settings_stack.append(settings)
+
+    @contextmanager
+    def _with_patched_context(self, **kwargs):
+        context = copy.copy(self._build_context_stack[-1])
+        for name, value in kwargs.items():
+            setattr(context, name, value)
+        self._build_context_stack.append(context)
+        yield
+        self._build_context_stack.pop()
+
+    @contextmanager
+    def with_metadata(self, metadata: TemplateMetadata):
+        """to single waveform
+
+        can be set in the pulse_template metadata or in the build_settings
+
+         - Should the program_builder know which template is translated currently?
+        """
+
+        # metadata.to_single_waveform == "always" is handled in PulseTemplate._build_program
+        if metadata.minimal_sample_rate is not None:
+            with self._with_patched_context(minimal_sample_rate=metadata.minimal_sample_rate) as builder:
+                yield builder
+        else:
+            yield self
+
+    @contextmanager
+    def with_transformation(self, transformation: Transformation):
+        context = copy.copy(self.build_context)
+        context.transformation = chain_transformations(context.transformation, transformation)
+        self._build_context_stack.append(context)
+        yield self
+        self._build_context_stack.pop()
+
+    @contextmanager
+    def with_mappings(self, *,
+                      parameter_mapping: Mapping[str, Expression],
+                      measurement_mapping: Mapping[str, Optional[str]],
+                      channel_mapping: Mapping[ChannelID, Optional[ChannelID]],
+                      ):
+        context = self.build_context.apply_mappings(parameter_mapping, measurement_mapping, channel_mapping)
+        self._build_context_stack.append(context)
+        yield self
+        self._build_context_stack.pop()
+
+    @abstractmethod
+    def _transformed_hold_voltage(self, duration: HardwareTime, voltages: Mapping[str, HardwareVoltage]):
+        """"""
+
+    @abstractmethod
+    def _transformed_play_arbitrary_waveform(self, waveform: Waveform):
+        """"""
+
+    def play_arbitrary_waveform(self, waveform: Waveform):
+        transformation = self.build_context.transformation
+        if transformation:
+            transformed_waveform = TransformingWaveform(waveform, transformation)
+            self._transformed_play_arbitrary_waveform(transformed_waveform)
+        else:
+            self._transformed_play_arbitrary_waveform(waveform)
+
+    def hold_voltage(self, duration: HardwareTime, voltages: Mapping[str, HardwareVoltage]):
+        transformation = self.build_context.transformation
+        if transformation:
+            if transformation.get_constant_output_channels(voltages.keys()) != transformation.get_output_channels(voltages.keys()):
+                waveform = TransformingWaveform(ConstantWaveform.from_mapping(duration, voltages), transformation)
+                self._transformed_play_arbitrary_waveform(waveform)
+            else:
+                transformed_voltages = transformation(0.0, voltages)
+                self._transformed_hold_voltage(duration, transformed_voltages)
+        else:
+            self._transformed_hold_voltage(duration, voltages)

--- a/qupulse/program/transformation.py
+++ b/qupulse/program/transformation.py
@@ -107,6 +107,9 @@ class IdentityTransformation(Transformation, metaclass=SingletonABCMeta):
     def get_constant_output_channels(self, input_channels: AbstractSet[ChannelID]) -> AbstractSet[ChannelID]:
         return input_channels
 
+    def __bool__(self):
+        return False
+
 
 class ChainedTransformation(Transformation):
     __slots__ = ('_transformations',)

--- a/qupulse/pulses/abstract_pulse_template.py
+++ b/qupulse/pulses/abstract_pulse_template.py
@@ -137,10 +137,8 @@ class AbstractPulseTemplate(PulseTemplate):
         else:
             raise RuntimeError('Cannot call "%s". No linked target to refer to', method_name)
 
-    def _internal_create_program(self, **kwargs):
-        raise NotImplementedError('this should never be called as we overrode _create_program')  # pragma: no cover
-
     _create_program = partialmethod(_forward_if_linked, '_create_program')
+    _build_program = partialmethod(_forward_if_linked, '_build_program')
 
     defined_channels = property(partial(_get_property, property_name='defined_channels'),
                                 doc=_PROPERTY_DOC.format(name='defined_channels'))

--- a/qupulse/pulses/mapping_pulse_template.py
+++ b/qupulse/pulses/mapping_pulse_template.py
@@ -347,22 +347,12 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
         return {inner_ch: None if outer_ch is None else channel_mapping[outer_ch]
                 for inner_ch, outer_ch in self.__channel_mapping.items()}
 
-    def _internal_create_program(self, *,
-                                 scope: Scope,
-                                 measurement_mapping: Dict[str, Optional[str]],
-                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
-                                 global_transformation: Optional['Transformation'],
-                                 to_single_waveform: Set[Union[str, 'PulseTemplate']],
-                                 program_builder: ProgramBuilder) -> None:
-        self.validate_scope(scope)
-
-        # parameters are validated in map_parameters() call, no need to do it here again explicitly
-        self.template._create_program(scope=self.map_scope(scope),
-                                      measurement_mapping=self.get_updated_measurement_mapping(measurement_mapping),
-                                      channel_mapping=self.get_updated_channel_mapping(channel_mapping),
-                                      global_transformation=global_transformation,
-                                      to_single_waveform=to_single_waveform,
-                                      program_builder=program_builder)
+    def _internal_build_program(self, program_builder: ProgramBuilder):
+        with program_builder.with_mappings(
+                parameter_mapping=self.__parameter_mapping,
+                channel_mapping=self.__channel_mapping,
+                measurement_mapping=self.__measurement_mapping) as inner_builder:
+            self.__template._build_program(program_builder=inner_builder)
 
     def build_waveform(self,
                        parameters: Dict[str, numbers.Real],

--- a/qupulse/pulses/measurement.py
+++ b/qupulse/pulses/measurement.py
@@ -35,7 +35,7 @@ class MeasurementDefiner:
 
     def get_measurement_windows(self,
                                 parameters: Union[Mapping[str, Real], Scope],
-                                measurement_mapping: Dict[str, Optional[str]]) -> List[MeasurementWindow]:
+                                measurement_mapping: Mapping[str, Optional[str]]) -> List[MeasurementWindow]:
         """Calculate measurement windows with the given parameter set and rename them with the measurement mapping. This
         method only returns the measurement windows that are defined on `self`. It does _not_ collect the measurement
         windows defined on eventual child objects that `self` has/is composed of.

--- a/qupulse/pulses/metadata.py
+++ b/qupulse/pulses/metadata.py
@@ -3,6 +3,7 @@ import dataclasses
 
 from typing import Literal, Optional
 
+from qupulse.utils.types import TimeType
 
 SingleWaveformStrategy = Literal['always']
 
@@ -17,11 +18,16 @@ class TemplateMetadata:
     """
 
     to_single_waveform: Optional[SingleWaveformStrategy] = dataclasses.field(default=None)
+    minimal_sample_rate: Optional[TimeType] = dataclasses.field(default=None)
 
-    def __init__(self, to_single_waveform: Optional[SingleWaveformStrategy] = None, **kwargs):
+    def __init__(self,
+                 to_single_waveform: Optional[SingleWaveformStrategy] = None,
+                 minimal_sample_rate: Optional[TimeType] = None,
+                 **kwargs):
         # TODO: generate this init automatically
         #       The reason for the custom init is that we want to allow additional kwargs
         self.to_single_waveform = to_single_waveform
+        self.minimal_sample_rate = minimal_sample_rate
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/qupulse/pulses/repetition_pulse_template.py
+++ b/qupulse/pulses/repetition_pulse_template.py
@@ -148,38 +148,7 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
 
         measurements = self.get_measurement_windows(scope, build_context.measurement_mapping)
         for repetition_program_builder in program_builder.with_repetition(repetition_definition, measurements=measurements):
-            self.body._build_program(repetition_program_builder)
-
-
-
-    def _internal_create_program(self, *,
-                                 scope: Scope,
-                                 measurement_mapping: Dict[str, Optional[str]],
-                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
-                                 global_transformation: Optional['Transformation'],
-                                 to_single_waveform: AbstractSet[Union[str, 'PulseTemplate']],
-                                 program_builder: ProgramBuilder) -> None:
-        self.validate_scope(scope)
-
-        repetition_count = max(0, self.get_repetition_count_value(scope))
-
-        if repetition_count > 0:
-            if scope.get_volatile_parameters().keys() & self.repetition_count.variables:
-                repetition_definition = VolatileRepetitionCount(self.repetition_count, scope)
-                assert int(repetition_definition) == repetition_count
-            else:
-                repetition_definition = repetition_count
-
-            measurements = self.get_measurement_windows(scope, measurement_mapping)
-
-            for repetition_program_builder in program_builder.with_repetition(repetition_definition,
-                                                                              measurements=measurements):
-                self.body._create_program(scope=repetition_program_builder.build_context.scope,
-                                          measurement_mapping=measurement_mapping,
-                                          channel_mapping=channel_mapping,
-                                          global_transformation=global_transformation,
-                                          to_single_waveform=to_single_waveform,
-                                          program_builder=repetition_program_builder)
+            self.body._build_program(program_builder=repetition_program_builder)
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         data = super().get_serialization_data(serializer)

--- a/qupulse/pulses/sequence_pulse_template.py
+++ b/qupulse/pulses/sequence_pulse_template.py
@@ -134,24 +134,12 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
             [sub_template.build_waveform(parameters, channel_mapping=channel_mapping)
              for sub_template in self.__subtemplates])
 
-    def _internal_create_program(self, *,
-                                 scope: Scope,
-                                 measurement_mapping: Dict[str, Optional[str]],
-                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
-                                 global_transformation: Optional['Transformation'],
-                                 to_single_waveform: Set[Union[str, 'PulseTemplate']],
-                                 program_builder: ProgramBuilder) -> None:
-        self.validate_scope(scope)
-
-        measurements = self.get_measurement_windows(scope, measurement_mapping)
+    def _internal_build_program(self, program_builder: ProgramBuilder):
+        build_context = program_builder.build_context
+        measurements = self.get_measurement_windows(build_context.scope, build_context.measurement_mapping)
         with program_builder.with_sequence(measurements=measurements) as sequence_program_builder:
             for subtemplate in self.subtemplates:
-                subtemplate._create_program(scope=scope,
-                                            measurement_mapping=measurement_mapping,
-                                            channel_mapping=channel_mapping,
-                                            global_transformation=global_transformation,
-                                            to_single_waveform=to_single_waveform,
-                                            program_builder=sequence_program_builder)
+                subtemplate._build_program(program_builder=sequence_program_builder)
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         data = super().get_serialization_data(serializer)

--- a/qupulse/pulses/time_reversal_pulse_template.py
+++ b/qupulse/pulses/time_reversal_pulse_template.py
@@ -57,10 +57,10 @@ class TimeReversalPulseTemplate(PulseTemplate):
     @property
     def final_values(self) -> Dict[ChannelID, ExpressionScalar]:
         return self._inner.initial_values
-    
-    def _internal_create_program(self, *, program_builder: ProgramBuilder, **kwargs) -> None:
-        with program_builder.time_reversed() as reversed_builder:
-            self._inner._internal_create_program(program_builder=reversed_builder, **kwargs)
+
+    def _internal_build_program(self, program_builder: ProgramBuilder):
+        with program_builder.time_reversed() as inner_program_builder:
+            self._inner._internal_build_program(inner_program_builder)
 
     def build_waveform(self,
                        *args, **kwargs) -> Optional[Waveform]:

--- a/tests/program/linspace_tests.py
+++ b/tests/program/linspace_tests.py
@@ -23,7 +23,7 @@ class SingleRampTest(TestCase):
         hold = ConstantPT(10 ** 6, {'a': '-1. + idx * 0.01'})
         self.pulse_template = hold.with_iteration('idx', 200)
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(
             length=200,
             body=(LinSpaceHold(
                 bases=(-1.,),
@@ -31,8 +31,7 @@ class SingleRampTest(TestCase):
                 duration_base=TimeType(10**6),
                 duration_factors=None
             ),)
-        ),),
-        {'a',})
+        ),), ("a",))
 
         key = DepKey.from_voltages((0.01,), DEFAULT_INCREMENT_RESOLUTION)
 
@@ -112,7 +111,7 @@ class SequencedRepetitionTest(TestCase):
             duration_factors=None
         )
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(
              length=rep_factor,
              body=(
                  dependent_hold_1,
@@ -120,7 +119,7 @@ class SequencedRepetitionTest(TestCase):
                  LinSpaceIter(body=(wait_hold,), length=rep_factor),
              )
         ),),
-        {'a','b'})
+            ('a','b'))
 
         self.commands = [
             Set(channel=0, value=-1.0, key=DepKey(factors=())),
@@ -209,7 +208,7 @@ class PrePostDepTest(TestCase):
         # self.pulse_template = (hold_random@(hold_random@hold).with_repetition(10)@hold_random@hold)\
         self.pulse_template = (hold_random @ hold.with_repetition(10)).with_iteration('idx', 200)
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(
             length=200,
             body=(
                 LinSpaceHold(bases=(-.4,), factors=(None,), duration_base=TimeType(10**5), duration_factors=None),
@@ -218,7 +217,9 @@ class PrePostDepTest(TestCase):
                 ), count=10),
                 # LinSpaceHold(bases=(-.4),factors=None,duration_base=TimeType(10**6),duration_factors=None),
                 # LinSpaceHold(bases=(-1.,),factors=((0.01,),),duration_base=TimeType(10**6),duration_factors=None)
-            ),),),{'a',})
+            ),),),
+            ('a',)
+        )
 
         self.commands = [
             Set(channel=0, value=-0.4, key=DepKey(factors=())),
@@ -270,7 +271,7 @@ class PlainCSDTest(TestCase):
         scan_a = hold.with_iteration('idx_a', 200)
         self.pulse_template = scan_a.with_iteration('idx_b', 100)
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(length=100, body=(LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(length=100, body=(LinSpaceIter(
             length=200,
             body=(LinSpaceHold(
                 bases=(-1., -0.5),
@@ -279,7 +280,7 @@ class PlainCSDTest(TestCase):
                 duration_base=TimeType(10**6),
                 duration_factors=None
             ),)
-        ),)),),{'a','b'})
+        ),)),), ('a', 'b'))
 
         key_0 = DepKey.from_voltages((0, 0.01,), DEFAULT_INCREMENT_RESOLUTION)
         key_1 = DepKey.from_voltages((0.02,), DEFAULT_INCREMENT_RESOLUTION)
@@ -342,7 +343,7 @@ class TiltedCSDTest(TestCase):
         self.pulse_template = scan_a.with_iteration('idx_b', 100)
         self.repeated_pt = self.pulse_template.with_repetition(repetition_count)
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(length=100, body=(LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(length=100, body=(LinSpaceIter(
             length=200,
             body=(LinSpaceHold(
                 bases=(-1., -0.5),
@@ -351,8 +352,8 @@ class TiltedCSDTest(TestCase):
                 duration_base=TimeType(10**6),
                 duration_factors=None
             ),)
-        ),)),),{'a','b'})
-        self.repeated_program = LinSpaceTopLevel((LinSpaceRepeat(body=self.program.body, count=repetition_count),),{'a','b'})
+        ),)),), ('a', 'b'))
+        self.repeated_program = LinSpaceProgram((LinSpaceRepeat(body=self.program.root, count=repetition_count),), ('a', 'b'))
 
         key_0 = DepKey.from_voltages((1e-3, 0.01,), DEFAULT_INCREMENT_RESOLUTION)
         key_1 = DepKey.from_voltages((0.02, -3e-3), DEFAULT_INCREMENT_RESOLUTION)
@@ -440,7 +441,7 @@ class SingletLoadProcessing(TestCase):
         singlet_scan = (load_random @ wait @ meas).with_iteration('idx_a', 200).with_iteration('idx_b', 100)
         self.pulse_template = singlet_scan
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(length=100, body=(LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(length=100, body=(LinSpaceIter(
             length=200,
             body=(
                 LinSpaceHold(bases=(-0.4, -0.3), factors=(None, None), duration_base=TimeType(10 ** 5),
@@ -453,7 +454,7 @@ class SingletLoadProcessing(TestCase):
                 LinSpaceHold(bases=(0.05, 0.06), factors=(None, None), duration_base=TimeType(10 ** 5),
                              duration_factors=None),
             )
-        ),)),),{'a','b'})
+        ),)),), ('a', 'b'))
 
         key_0 = DepKey.from_voltages((0, 0.01,), DEFAULT_INCREMENT_RESOLUTION)
         key_1 = DepKey.from_voltages((0.02,), DEFAULT_INCREMENT_RESOLUTION)
@@ -549,7 +550,7 @@ class TransformedRampTest(TestCase):
         self.pulse_template = hold.with_iteration('idx', 200)
         self.transformation = ScalingTransformation({'a': 2.0})
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(
             length=200,
             body=(LinSpaceHold(
                 bases=(-2.,),
@@ -557,7 +558,7 @@ class TransformedRampTest(TestCase):
                 duration_base=TimeType(10 ** 6),
                 duration_factors=None
             ),)
-        ),),{'a',})
+        ),), ('a',))
 
     def test_global_trafo_program(self):
         program_builder = LinSpaceBuilder(('a',))
@@ -584,7 +585,7 @@ class HarmonicPulseTest(TestCase):
 
         self.sine_waveform = sine.build_waveform(parameters={}, channel_mapping={'a': 'a'})
 
-        self.program = LinSpaceTopLevel((LinSpaceIter(
+        self.program = LinSpaceProgram((LinSpaceIter(
             length=100,
             body=(LinSpaceHold(
                 bases=(-1.,),
@@ -597,7 +598,7 @@ class HarmonicPulseTest(TestCase):
                 channels=('a',)
             )
             )
-        ),),{'a',})
+        ),),('a',))
 
         key = DepKey.from_voltages((0.01,), DEFAULT_INCREMENT_RESOLUTION)
         self.commands = [

--- a/tests/pulses/constant_pulse_template_tests.py
+++ b/tests/pulses/constant_pulse_template_tests.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 import qupulse.plotting
 import qupulse.program.waveforms
@@ -44,10 +45,7 @@ class TestConstantPulseTemplate(unittest.TestCase):
         self.assertEqual(pulse.duration, 12)
 
     def test_regression_duration_conversion(self):
-        old_value = qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR
-
-        try:
-            qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
+        with mock.patch("qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR", 1e-6):
             for duration_in_samples in [64, 936320, 24615392]:
                 p = ConstantPulseTemplate(duration_in_samples / 2.4, {'a': 0})
                 number_of_samples = p.create_program().duration * 2.4
@@ -56,33 +54,21 @@ class TestConstantPulseTemplate(unittest.TestCase):
 
                 p2 = ConstantPulseTemplate((duration_in_samples + 1) / 2.4, {'a': 0})
                 self.assertNotEqual(p.create_program().duration, p2.create_program().duration)
-        finally:
-            qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_duration_conversion_functionpt(self):
-        old_value = qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR
-
-        try:
-            qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR = 1e-6
+        with mock.patch("qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR", 1e-6):
             for duration_in_samples in [64, 2000, 936320]:
                 p = FunctionPT('1', duration_expression=duration_in_samples / 2.4, channel='a')
                 number_of_samples = p.create_program().duration * 2.4
                 self.assertEqual(number_of_samples.denominator, 1)
-        finally:
-            qupulse.program.waveforms.PULSE_TO_WAVEFORM_ERROR = old_value
 
     def test_regression_template_combination(self):
-        old_value = qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN
-
-        try:
-            qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN = 1e-9
+        with mock.patch("qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN", 1e-9):
             duration_in_seconds = 2e-6
             full_template = ConstantPulseTemplate(duration=duration_in_seconds * 1e9, amplitude_dict={'C1': 1.1})
             duration_in_seconds_derived = 1e-9 * full_template.duration
             marker_pulse = TablePT({'marker': [(0, 0), (duration_in_seconds_derived * 1e9, 0)]})
             full_template = AtomicMultiChannelPT(full_template, marker_pulse)
-        finally:
-            qupulse.utils.sympy.SYMPY_DURATION_ERROR_MARGIN = old_value
 
     def test_regression_sequencept_with_mappingpt(self):
         t1 = TablePT({'C1': [(0, 0), (100, 0)], 'C2': [(0, 1), (100, 1)]})

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -440,14 +440,6 @@ class ParallelChannelPulseTemplateTests(unittest.TestCase):
             program_builder.with_transformation.assert_called_once_with(expected_transformation)
             cp_mock.assert_called_once_with(program_builder=program_builder.with_transformation.return_value.__enter__.return_value)
 
-        global_transformation = LinearTransformation(numpy.zeros((0, 0)), [], [])
-        expected_transformation = chain_transformations(global_transformation, expected_transformation)
-
-        with mock.patch.object(template, '_build_program', spec=template._build_program) as cp_mock:
-            pccpt._internal_build_program(program_builder)
-            program_builder.with_transformation.assert_called_once_with(expected_transformation)
-            cp_mock.assert_called_once_with(program_builder=program_builder.with_transformation.return_value.__enter__.return_value)
-
     def test_build_waveform(self):
         template = DummyPulseTemplate(duration='t1', defined_channels={'X', 'Y'}, parameter_names={'a', 'b'},
                                       measurement_names={'M'}, waveform=DummyWaveform())

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -81,7 +81,7 @@ class PulseTemplateStub(PulseTemplate):
                                  channel_mapping: Dict[ChannelID, Optional[ChannelID]],
                                  global_transformation: Optional[Transformation],
                                  to_single_waveform: Set[Union[str, 'PulseTemplate']],
-                                 parent_loop: Loop):
+                                 program_builder):
         raise NotImplementedError()
 
     @property
@@ -215,12 +215,13 @@ class PulseTemplateTest(unittest.TestCase):
 
         template = PulseTemplateStub()
         with mock.patch.object(template, '_internal_create_program') as _internal_create_program:
-            template._create_program(scope=scope,
-                                     measurement_mapping=measurement_mapping,
-                                     channel_mapping=channel_mapping,
-                                     global_transformation=global_transformation,
-                                     to_single_waveform=to_single_waveform,
-                                     program_builder=program_builder)
+            with self.assertWarns(DeprecationWarning):
+                template._create_program(scope=scope,
+                                         measurement_mapping=measurement_mapping,
+                                         channel_mapping=channel_mapping,
+                                         global_transformation=global_transformation,
+                                         to_single_waveform=to_single_waveform,
+                                         program_builder=program_builder)
 
             _internal_create_program.assert_called_once_with(
                 scope=scope,
@@ -234,12 +235,13 @@ class PulseTemplateTest(unittest.TestCase):
 
             with self.assertRaisesRegex(NotImplementedError, "volatile"):
                 template._parameter_names = {'c'}
-                template._create_program(scope=scope,
-                                         measurement_mapping=measurement_mapping,
-                                         channel_mapping=channel_mapping,
-                                         global_transformation=global_transformation,
-                                         to_single_waveform={template},
-                                         program_builder=program_builder)
+                with self.assertWarns(DeprecationWarning):
+                    template._create_program(scope=scope,
+                                             measurement_mapping=measurement_mapping,
+                                             channel_mapping=channel_mapping,
+                                             global_transformation=global_transformation,
+                                             to_single_waveform={template},
+                                             program_builder=program_builder)
 
     def test__create_program_single_waveform(self):
         template = PulseTemplateStub(identifier='pt_identifier', parameter_names={'alpha'})
@@ -276,12 +278,13 @@ class PulseTemplateTest(unittest.TestCase):
                     with mock.patch('qupulse.program.loop.to_waveform',
                                     return_value=single_waveform) as to_waveform:
                         with mock.patch('qupulse.program.loop.LoopBuilder', return_value=inner_program_builder):
-                            template._create_program(scope=scope,
-                                                     measurement_mapping=measurement_mapping,
-                                                     channel_mapping=channel_mapping,
-                                                     global_transformation=global_transformation,
-                                                     to_single_waveform=to_single_waveform,
-                                                     program_builder=program_builder)
+                            with self.assertWarns(DeprecationWarning):
+                                template._create_program(scope=scope,
+                                                         measurement_mapping=measurement_mapping,
+                                                         channel_mapping=channel_mapping,
+                                                         global_transformation=global_transformation,
+                                                         to_single_waveform=to_single_waveform,
+                                                         program_builder=program_builder)
 
                         _internal_create_program.assert_called_once_with(scope=scope,
                                                                          measurement_mapping=measurement_mapping,


### PR DESCRIPTION
This PR replaces `PulseTemplate._create_program(**a_lot_of__kwargs)` with `PulseTemplate._build_program(program_builder)`.

It moves all the information about the current scope, transformations, channel and measurement mappings into the program builder.

 - Add `ProgramBuilder.build_context: BuildContext`: A dataclass with mutable information like the current scope
 - Add `ProgramBuilder.build_settings: BuildSettings`: A dataclass with constant information like which templates to translate into a single waveform
 - Add `Program.get_defined_channels`.
 - Add `ProgramBuilder.override` to modify the current built settings/context.
 - Add `ProgramBuilder.with_mappings` for `MappingPT`
 - Add `ProgramBuilder.with_transformation` for arithmetic and channel modification PTs
 - Add `ProgramBuilder.with_metadata` for a semi standadized metadata passing. The only read metadata right now is the minimal sample rate.
 - Remove `ProgramBuilder.inner_scope` because it is no longer required.

To reduce code duplication the PR contains the `BaseProgramBuilder` class which contains some default implementations for context management which are shared between the loop and linspace builder.

TODO:

 - [x] fix other tests
 - [x] motivate split between BuildSettings and BuildContext or merge them
 - [x] Transform the PR text into a newspiece